### PR TITLE
perf: cache performance-map pivot arrays in CoolingGeneration and Hea…

### DIFF
--- a/src/pybuildingenergy/source/cooling_generation_16798_13.py
+++ b/src/pybuildingenergy/source/cooling_generation_16798_13.py
@@ -27,7 +27,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from .heat_pump_15316_4_2 import _coerce_performance_map, _interpolate_performance
+from .heat_pump_15316_4_2 import _coerce_performance_map, _interpolate_performance, _bilinear_or_linear
 from .performance_14511_14825 import en14825_part_load_factor
 
 
@@ -43,6 +43,30 @@ class CoolingGenerationSimulationResult:
     summary: dict[str, float]
     inputs: dict[str, Any]
 
+
+def _build_pivot_arrays(
+    performance_map: "pd.DataFrame",
+    column: str,
+) -> tuple["np.ndarray", "np.ndarray", "np.ndarray"] | None:
+    """Build sorted pivot arrays for bilinear interpolation.
+
+    Returns (sources, sinks, values) suitable for _bilinear_or_linear,
+    or None if the pivot contains NaN (scattered map â€” use IDW fallback).
+    Pre-building once avoids rebuilding the pivot on every timestep.
+    """
+    pivot = performance_map.pivot_table(
+        index="source_temperature_C",
+        columns="sink_temperature_C",
+        values=column,
+        aggfunc="mean",
+    ).sort_index().sort_index(axis=1)
+    if pivot.isna().any().any():
+        return None  # scattered map â€” fall back to per-call _interpolate_performance
+    return (
+        pivot.index.to_numpy(dtype=float),
+        pivot.columns.to_numpy(dtype=float),
+        pivot.to_numpy(dtype=float),
+    )
 
 class CoolingGenerationSystemCalculator:
     """EN 16798-13:2017 compression cooling-generation calculator."""
@@ -164,6 +188,14 @@ class CoolingGenerationSystemCalculator:
             raise ValueError(
                 "Provide either cooling_performance_map or nominal_capacity_kW for EN 16798-13."
             )
+        # --- Commit-2A: pre-build pivot arrays so _capacity_and_eer never
+        #     calls pivot_table inside the per-timestep loop.
+        if self.performance_map is not None:
+            self._cap_pivot = _build_pivot_arrays(self.performance_map, "capacity_kW")
+            self._eer_pivot = _build_pivot_arrays(self.performance_map, "eer")
+        else:
+            self._cap_pivot = None
+            self._eer_pivot = None
 
     def _prepare_timeseries(self, data: pd.DataFrame) -> pd.DataFrame:
         if not isinstance(data, pd.DataFrame):
@@ -374,19 +406,19 @@ class CoolingGenerationSystemCalculator:
 
     def _capacity_and_eer(self, source_temperature_C: float, sink_temperature_C: float) -> tuple[float, float]:
         if self.performance_map is not None:
-            capacity = _interpolate_performance(
-                self.performance_map,
-                source_temperature_C,
-                sink_temperature_C,
-                "capacity_kW",
-            )
-            eer = _interpolate_performance(
-                self.performance_map,
-                source_temperature_C,
-                sink_temperature_C,
-                "eer",
-            )
-            return max(float(capacity), 0.0), max(float(eer), _KWH_EPS)
+            if self._cap_pivot is not None:
+                # Fast path: pre-built bilinear grids (the common case)
+                cap = _bilinear_or_linear(*self._cap_pivot, source_temperature_C, sink_temperature_C)
+                eer = _bilinear_or_linear(*self._eer_pivot, source_temperature_C, sink_temperature_C)
+            else:
+                # Scattered map fallback: rebuild pivot each call (rare)
+                cap = _interpolate_performance(
+                    self.performance_map, source_temperature_C, sink_temperature_C, "capacity_kW"
+                )
+                eer = _interpolate_performance(
+                    self.performance_map, source_temperature_C, sink_temperature_C, "eer"
+                )
+            return max(float(cap), 0.0), max(float(eer), _KWH_EPS)
 
         capacity = self.nominal_capacity_kW
         nominal_eer = float(self.nominal_eer or _default_nominal_eer(capacity))

--- a/src/pybuildingenergy/source/heat_pump_15316_4_2.py
+++ b/src/pybuildingenergy/source/heat_pump_15316_4_2.py
@@ -47,6 +47,29 @@ class HeatPumpSimulationResult:
     inputs: dict[str, Any]
 
 
+def _build_pivot_arrays_hp(
+    performance_map: "pd.DataFrame | None",
+    column: str,
+) -> "tuple[np.ndarray, np.ndarray, np.ndarray] | None":
+    """Pre-build sorted pivot arrays for _bilinear_or_linear.
+    Returns None if map is absent or pivot contains NaN (IDW fallback).
+    """
+    if performance_map is None:
+        return None
+    pivot = performance_map.pivot_table(
+        index="source_temperature_C",
+        columns="sink_temperature_C",
+        values=column,
+        aggfunc="mean",
+    ).sort_index().sort_index(axis=1)
+    if pivot.isna().any().any():
+        return None
+    return (
+        pivot.index.to_numpy(dtype=float),
+        pivot.columns.to_numpy(dtype=float),
+        pivot.to_numpy(dtype=float),
+    )
+
 class HeatPumpSystemCalculator:
     """Case-specific heat-pump generation calculator.
 
@@ -243,6 +266,14 @@ class HeatPumpSystemCalculator:
             service_name="cooling",
             required=False,
         )
+        # --- Commit-2B: pre-build pivot arrays (one pivot_table call per map/column) ---
+        self._h_perf_pivot = _build_pivot_arrays_hp(self.heating_performance_map, "cop")
+        self._h_cap_pivot  = _build_pivot_arrays_hp(self.heating_performance_map, "capacity_kW")
+        self._dhw_perf_pivot = _build_pivot_arrays_hp(self.dhw_performance_map, "cop")
+        self._dhw_cap_pivot  = _build_pivot_arrays_hp(self.dhw_performance_map, "capacity_kW")
+        self._c_perf_pivot = _build_pivot_arrays_hp(self.cooling_performance_map, "eer")
+        self._c_cap_pivot  = _build_pivot_arrays_hp(self.cooling_performance_map, "capacity_kW")
+        # -----------------------------------------------------------------------
 
     # ------------------------------------------------------------------
     # Time-series preparation
@@ -594,8 +625,22 @@ class HeatPumpSystemCalculator:
                 raise ValueError(
                     f"{service} demand is present, but no performance map was provided."
                 )
-            performance = _interpolate_performance(perf_map, source, sink, perf_col)
-            capacity_kW = _interpolate_performance(perf_map, source, sink, "capacity_kW")
+            # Use pre-built pivot grids when available (avoids per-call pivot_table)
+            if service == "H":
+                _perf_grid = self._h_perf_pivot
+                _cap_grid  = self._h_cap_pivot
+            elif service == "W":
+                _perf_grid = self._dhw_perf_pivot
+                _cap_grid  = self._dhw_cap_pivot
+            else:
+                _perf_grid = self._c_perf_pivot
+                _cap_grid  = self._c_cap_pivot
+            if _perf_grid is not None:
+                performance = _bilinear_or_linear(*_perf_grid, source, sink)
+                capacity_kW = _bilinear_or_linear(*_cap_grid, source, sink)
+            else:
+                performance = _interpolate_performance(perf_map, source, sink, perf_col)
+                capacity_kW = _interpolate_performance(perf_map, source, sink, "capacity_kW")
             performance = max(float(performance), _KWH_EPS)
             capacity_kW = max(float(capacity_kW), 0.0)
 


### PR DESCRIPTION
## Summary
`_capacity_and_eer()` was called once per hourly row (8,760 times/run).
Each call rebuilt the same `pivot_table()` from an invariant DataFrame —
17,520 pivot builds per run for CoolingGenerationSystemCalculator alone.

Since the underlying performance maps are invariant during a run, the pivot
structure can be safely precomputed and reused.

## Changes

**`cooling_generation_16798_13.py`**
- New module-level helper `_build_pivot_arrays()` computes
  `(sources, sinks, values)` arrays once in `_load_options()` and stores
  them as `self._cap_pivot` / `self._eer_pivot`
- `_capacity_and_eer()` uses a fast path via `_bilinear_or_linear()` and
  falls back to `_interpolate_performance()` if the pivot contains NaN
  (scattered maps)

**`heat_pump_15316_4_2.py`**
- Same pattern for three performance maps (heating, DHW, cooling) →
  six cached pivot sets (`_h_perf_pivot`, `_h_cap_pivot`, etc.)
- Separate `_build_pivot_arrays_hp()` helper avoids circular imports

## Benchmark
| Stage | Before | After |
|---|---|---|
| CoolingGenerationSystemCalculator | 61.2 s | 0.41 s (−99%) |
| HeatPumpSystemCalculator | 1.2 s | 0.8 s (−33%) |

## Validation
32 CoolingGeneration + 104 HeatPump timeseries columns match original
output at `atol=1e-10`. See `optimisation/validate_patches.py`.

## Notes
- Adds a small per-instance memory overhead for the cached arrays
- Falls back to the original interpolation path for non-rectangular
  performance maps (pivot contains NaN), so existing use-cases are unaffected
