### PR TITLE
feat: add sensible AHU as mechanical supply

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -405,6 +405,44 @@ Due to the need to have profiles of occupancy and consumption of buildings for s
 These tables are provided by ANNEX A of ISO EN 16798-1. 
 In the tool they are available here: [Table](https://github.com/EURAC-EEBgroup/pyBuildingEnergy/blob/master/src/pybuildingenergy/source/table_iso_16798_1.py)
 
+## EN 16798-5-1 - Mechanical Ventilation AHU **(New)**
+
+A sensible, balanced-airflow air-handling-unit model based on EN 16798-5-1 can
+be configured as a `mechanical_supply` ventilation component. It computes heat
+recovery, bypass and frost behaviour, capacity-limited heating/cooling coils
+and fan electricity per timestep, and couples into the ISO 52016-1 zone
+balance as a supply-air stream. Existing configurations are unchanged unless
+the component is configured.
+
+```python
+"building_parameters": {
+    "ventilation": {
+        "components": [
+            {   # envelope leakage: no profile, always active
+                "name": "infiltration",
+                "ventilation_type": "constant_ach",
+                "air_changes_per_hour": 0.15,
+            },
+            {   # balanced AHU with sensible heat recovery
+                "name": "ahu",
+                "ventilation_type": "mechanical_supply",
+                "supply_flow_m3_h": 3600.0,
+                "sensible_heat_recovery_efficiency": 0.784,
+                "supply_temperature_setpoint_c": 18.0,
+                "heating_coil_max_power_w": 15000.0,
+                "supply_fan_specific_power_w_per_m3_s": 750.0,
+                "extract_fan_specific_power_w_per_m3_s": 750.0,
+                "profile": "ventilation_profile",  # flow fraction in [0, 1]
+            },
+        ],
+    },
+},
+```
+
+For the implemented / simplified / not-included scope, all configuration keys
+and the hourly diagnostic columns, open
+[Ventilation AHU EN 16798-5-1 Implementation Audit](docs/ventilation_ahu_audit.html).
+
 ## Input Quality check  **(New)**
 
 The data provided before being used for the simulation are processed and evaluated to be considered fit for the simulation. This process includes a series of checks that allow to identify any potential errors. 

--- a/docs/simulation_workflow_audit.html
+++ b/docs/simulation_workflow_audit.html
@@ -156,6 +156,7 @@
     <tr><td><a href="performance_14511_14825_audit.html">EN 14511 / EN 14825 product performance audit</a></td><td>Rating-point normalization, COP/EER maps and part-load correction.</td></tr>
     <tr><td><a href="heat_pump_15316_4_2_audit.html">Heat pump EN 15316-4-2 audit</a></td><td>Heating/DHW temperature-bin generation, capacity checks, backup, auxiliaries and SPF.</td></tr>
     <tr><td><a href="cooling_16798_audit.html">Cooling EN 16798 audit</a></td><td>Cooling operating conditions, chilled storage and compression cooling generation.</td></tr>
+    <tr><td><a href="ventilation_ahu_audit.html">Ventilation AHU EN 16798-5-1 audit</a></td><td>Sensible AHU model behind the ISO 52016-1 ventilation boundary: heat recovery, frost/bypass behaviour, coils, fans, lagged extract-air coupling, and the implemented/simplified/not-included scope.</td></tr>
   </table>
 
   <h2>Primary Output Files</h2>

--- a/docs/ventilation_ahu_audit.html
+++ b/docs/ventilation_ahu_audit.html
@@ -1,0 +1,458 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>EN 16798-5-1 Sensible AHU Implementation Audit</title>
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.55; margin: 32px; color: #1f2933; }
+    h1, h2, h3 { color: #102a43; }
+    code { background: #eef2f7; padding: 2px 5px; border-radius: 4px; }
+    pre { background: #f8fafc; border: 1px solid #d7dde5; padding: 12px 14px; overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; margin: 18px 0 28px; }
+    th, td { border: 1px solid #d7dde5; padding: 10px; vertical-align: top; }
+    th { background: #f3f6fa; text-align: left; }
+    .note { background: #f8fafc; border-left: 4px solid #607d9c; padding: 12px 16px; }
+    .ok { color: #1f7a4d; font-weight: 700; }
+    .partial { color: #956000; font-weight: 700; }
+    .no { color: #8b1e2d; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <h1>EN 16798-5-1 Sensible AHU Implementation Audit</h1>
+
+  <p>
+    This page maps the air-handling-unit (AHU) module
+    <code>src/pybuildingenergy/source/ventilation_16798_5_1.py</code> to
+    <strong>EN 16798-5-1, Energy performance of buildings - Ventilation for
+    buildings - Part 5-1: Calculation methods for energy requirements of
+    ventilation and air conditioning systems (Methods M5-6, M5-8, M6-5, M6-8,
+    M7-5, M7-8) - Method 1: Distribution and generation</strong>.
+    The module sits in the EPB ventilation chain ISO 52016-1 (zone heat
+    balance) &rarr; EN 16798-7 (required zone airflow) &rarr; EN 16798-5-1
+    (AHU and system energy). It describes the calculation structure at a
+    high level and does not reproduce protected standard text; the standard
+    itself remains required to understand and verify the method.
+  </p>
+
+  <h2>Architecture And Solver Coupling</h2>
+  <p>
+    The AHU calculation is solver-independent. Each timestep it receives
+    outdoor temperature, extract-air temperature, required airflow and a
+    supply-temperature setpoint, and returns the delivered supply temperature
+    plus system-energy diagnostics. The result enters the zone heat balance
+    only through the existing ISO 52016-1 &sect;6.5.10 affine ventilation
+    boundary as one additive stream with conductance
+    <code>H_k = rho_air &middot; cp_air &middot; q_supply</code> and source
+    temperature equal to the delivered supply temperature. The zone matrix
+    formulation is unchanged and no solver iterations are added.
+  </p>
+
+  <pre><code>outdoor air (ODA)
+  -> sensible heat recovery   (frost-limited effectiveness, modulating bypass)
+  -> sensible cooling coil    (optional, capacity-limited)
+  -> sensible heating coil    (capacity-limited)
+  -> supply fan heat          (configured fraction to air)
+  -> supply stream (H_k, T_supply) -> ISO 52016-1 &sect;6.5.10 boundary
+
+extract air (ETA = lagged zone air temperature)
+  -> extract fan heat         (configured fraction to air, before heat recovery)
+  -> heat-recovery exhaust side -> exhaust air (EHA, frost-limit check)</code></pre>
+
+  <div class="note">
+    <strong>Lagged extract-air coupling.</strong> The extract-air temperature
+    is the zone <em>air-node</em> temperature from the previous timestep (not
+    the operative temperature). This is an explicit lagged-coupling assumption:
+    it avoids the algebraic loop T_zone &rarr; T_extract &rarr; heat
+    recovery/coils &rarr; T_supply &rarr; T_zone and preserves the existing
+    single-pass solver workflow. For hourly EPB-style simulation this is a
+    reasonable first coupling; for very high air-change rates, short zone time
+    constants or tight extract-temperature control an iterative or implicit
+    coupling would be a future option.
+  </div>
+
+  <p>Three levels of ventilation modelling coexist; the AHU level is strictly opt-in:</p>
+  <table>
+    <tr><th>Level</th><th>Configuration</th><th>Behaviour</th></tr>
+    <tr>
+      <td>Simple (default)</td>
+      <td>Existing <code>ventilation_type</code> values or
+          <code>constant_ach</code> components</td>
+      <td>Outdoor-air ventilation/infiltration path, unchanged. No AHU system
+          calculation.</td>
+    </tr>
+    <tr>
+      <td>Prescribed supply</td>
+      <td><code>prescribed</code> component</td>
+      <td>User supplies <code>H_k</code> and a known supply temperature
+          directly. Intermediate option when the supply condition is computed
+          externally.</td>
+    </tr>
+    <tr>
+      <td>Detailed AHU (this module)</td>
+      <td><code>mechanical_supply</code> component</td>
+      <td>Heat recovery, frost/bypass behaviour, coils and fans are computed
+          per timestep from EN 16798-5-1 sensible relations; the resulting
+          supply stream and diagnostics are returned.</td>
+    </tr>
+  </table>
+
+  <h2>Coverage: Implemented, Simplified, Not Included</h2>
+
+  <h3>Implemented</h3>
+  <table>
+    <tr><th>Functionality</th><th>Notes</th><th>Status</th></tr>
+    <tr>
+      <td>Balanced single-zone supply and extract airflow</td>
+      <td>Constant-air-volume operation per timestep; supply and extract flow
+          must be equal (enforced).</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Sensible heat recovery</td>
+      <td>Configured temperature efficiency (effectiveness) applied between
+          extract and outdoor streams.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Heat-recovery bypass with continuous modulation</td>
+      <td><code>modulating_bypass</code> tracks the supply setpoint by mixing
+          outdoor air with heat-recovery outlet air; <code>always_on</code>
+          disables modulation. In economizer conditions (outdoor warmer than
+          extract) the heat recovery is modulated continuously rather than
+          switched, so supply delivery is consistent across all conditions.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Frost protection by exhaust-temperature limit</td>
+      <td><code>exhaust_limit</code> mode reduces the effective heat-recovery
+          efficiency so the exhaust leaving the recovery core stays at or above
+          a configured limit, following the direct frost-protection approach of
+          EN 16798-5-1 (cf. formula (46)).</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Sensible heating coil with capacity limit</td>
+      <td>Raises supply air to the (fan-heat-adjusted) setpoint; optional
+          maximum power.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Sensible cooling coil with capacity limit</td>
+      <td>Opt-in (<code>cooling_coil_enabled</code>); placed before the heating
+          coil in the air path per the standard sequence. With a single supply
+          setpoint the two coils are mutually exclusive within a timestep.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Required vs. delivered coil power (unmet demand)</td>
+      <td>Required and actual powers are reported separately for both coils;
+          a disabled or capacity-limited coil exposes its shortfall instead of
+          hiding it.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Fan electricity, single-zone relations</td>
+      <td>Default <code>en16798_5_1</code> model: design pressure from nominal
+          specific fan power and nominal efficiency, part-load pressure
+          proportional to the square of the flow ratio, fan efficiency with the
+          product-data square-root flow correction. A
+          <code>constant_sfp</code> alternative keeps the legacy
+          P&nbsp;=&nbsp;q&nbsp;&middot;&nbsp;SFP relation. Both are identical at
+          design flow.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Fan heat to the airstreams</td>
+      <td>Configured fraction of each fan's power heats its airstream. Extract
+          fan heat is added before heat recovery (increasing recovery);
+          supply fan heat after the coils (the coil target compensates so the
+          delivered temperature still meets the setpoint).</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td>Supply-temperature control: fixed and outdoor-compensated</td>
+      <td>Fixed setpoint, or piecewise-linear outdoor-compensation curve with
+          endpoint clamping and optional min/max limits; these correspond to
+          the controller strategies enumerated in EN 16798-5-1 Table B.2.
+          A scheduled (per-timestep external setpoint) mode exists at the
+          library API level.</td>
+      <td><span class="ok">Implemented</span></td>
+    </tr>
+  </table>
+
+  <h3>Simplified Or User-Supplied</h3>
+  <table>
+    <tr><th>Item</th><th>Simplification</th><th>Status</th></tr>
+    <tr>
+      <td>Extract-air temperature</td>
+      <td>Previous-timestep zone air-node temperature (lagged coupling, see
+          note above). Not iterated within the timestep.</td>
+      <td><span class="partial">Simplified</span></td>
+    </tr>
+    <tr>
+      <td>Air properties</td>
+      <td>Fixed rho&nbsp;=&nbsp;1.204&nbsp;kg/m&sup3;,
+          cp&nbsp;=&nbsp;1006&nbsp;J/(kg&middot;K)
+          (rho&middot;cp&nbsp;=&nbsp;1211.224&nbsp;J/(m&sup3;&middot;K)),
+          following the existing <code>ventilation.py</code> convention. No
+          altitude-corrected air density, no humidity dependence.</td>
+      <td><span class="partial">Simplified</span></td>
+    </tr>
+    <tr>
+      <td>Frost protection</td>
+      <td>Only the direct effectiveness-reduction approach (cf. formula (46)).
+          The indirect treatment computing frost-protected outdoor-air and
+          limited heat-recovery supply temperatures (cf. formulas (47b)-(49))
+          is not implemented, and the physical defrost mechanism (bypass,
+          preheater, recirculation) is not modelled as equipment.</td>
+      <td><span class="partial">Simplified</span></td>
+    </tr>
+    <tr>
+      <td>Extract-compensated supply-temperature control</td>
+      <td>Provided as a generic piecewise-linear controller on extract (zone)
+          temperature. This supervisory strategy fits the architecture of
+          EN 16798-5-1 but is <em>not</em> one of the controller modes
+          enumerated in Table B.2.</td>
+      <td><span class="partial">Extension beyond Table B.2</span></td>
+    </tr>
+    <tr>
+      <td>Fan product data</td>
+      <td>When not supplied: design pressure is derived from nominal specific
+          fan power and nominal efficiency; nominal efficiencies default to
+          0.72 (supply) and 0.78 (extract); reference flow/efficiency for the
+          part-load efficiency correction default to the design values. These
+          defaults stand in for product data and should be replaced with
+          manufacturer values in project studies.</td>
+      <td><span class="partial">User-supplied / defaulted</span></td>
+    </tr>
+    <tr>
+      <td>Fan heat fraction to air</td>
+      <td>Defaults to 0.90 for both fans. Set the extract value to 0 for an
+          extract fan downstream of heat recovery.</td>
+      <td><span class="partial">User-supplied / defaulted</span></td>
+    </tr>
+    <tr>
+      <td>Ventilation profile fractions</td>
+      <td>A fractional profile value scales the operating airflow continuously
+          (reduced fan speed), with fan power following the part-load
+          relations. It is <em>not</em> ON/OFF duty-cycle averaging. The
+          library API has a separate <code>operation_fraction</code> input for
+          duty-cycle averaging, which the solver path does not use.</td>
+      <td><span class="partial">Convention</span></td>
+    </tr>
+    <tr>
+      <td>Reported bypass fraction</td>
+      <td><code>bypass_fraction</code> is the effective fraction of supply air
+          bypassing the recovery core derived from actual vs. nominal recovery
+          (frost reduction plus setpoint modulation combined); it is not a
+          physical damper position.</td>
+      <td><span class="partial">Diagnostic convention</span></td>
+    </tr>
+  </table>
+
+  <h3>Not Included In This Version</h3>
+  <table>
+    <tr><th>Functionality</th><th>Status</th></tr>
+    <tr><td>Latent cooling and dehumidification</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Humidity recovery and humidification</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Recirculation</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Airflow leakage, AHU casing and duct losses</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Ground preheating (earth-to-air heat exchangers)</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Unbalanced supply/extract airflow</td><td><span class="no">Not included (rejected with an error)</span></td></tr>
+    <tr><td>Multi-zone air distribution and detailed VAV control</td><td><span class="no">Not included</span></td></tr>
+    <tr><td>Indirect frost treatment and explicit defrost equipment (preheater, recirculation defrost)</td><td><span class="no">Not included</span></td></tr>
+  </table>
+
+  <h2>Main Inputs (<code>mechanical_supply</code> Component Schema)</h2>
+  <table>
+    <tr><th>Input</th><th>Key</th><th>Default</th><th>Role</th></tr>
+    <tr>
+      <td>Supply airflow</td>
+      <td><code>supply_flow_m3_h</code> (required), <code>extract_flow_m3_h</code></td>
+      <td>extract = supply</td>
+      <td>Design/required balanced airflow; extract must equal supply.</td>
+    </tr>
+    <tr>
+      <td>Heat-recovery efficiency</td>
+      <td><code>sensible_heat_recovery_efficiency</code> (required)</td>
+      <td>-</td>
+      <td>Sensible temperature efficiency in [0, 1].</td>
+    </tr>
+    <tr>
+      <td>Supply-temperature control</td>
+      <td><code>supply_temperature_mode</code>:
+          <code>"fixed"</code> with <code>supply_temperature_setpoint_c</code>, or
+          <code>"outdoor_compensated"</code> / <code>"extract_compensated"</code>
+          with <code>supply_temperature_points</code> ([T_ref, T_sup] pairs) and
+          optional <code>supply_temperature_minimum_c</code> /
+          <code>supply_temperature_maximum_c</code></td>
+      <td><code>"fixed"</code></td>
+      <td>Requested supply-air setpoint per timestep.</td>
+    </tr>
+    <tr>
+      <td>Heat-recovery control</td>
+      <td><code>heat_recovery_control</code></td>
+      <td><code>"modulating_bypass"</code></td>
+      <td><code>"modulating_bypass"</code> or <code>"always_on"</code>.</td>
+    </tr>
+    <tr>
+      <td>Frost protection</td>
+      <td><code>frost_control</code>, <code>frost_exhaust_limit_c</code></td>
+      <td><code>"exhaust_limit"</code>, -5&nbsp;&deg;C</td>
+      <td>Minimum allowed exhaust temperature leaving the recovery core.</td>
+    </tr>
+    <tr>
+      <td>Coils</td>
+      <td><code>heating_coil_max_power_w</code>, <code>cooling_coil_enabled</code>,
+          <code>cooling_coil_max_power_w</code></td>
+      <td>unlimited, <code>false</code>, unlimited</td>
+      <td>Capacity limits; disabled cooling still reports required (unmet) power.</td>
+    </tr>
+    <tr>
+      <td>Fans</td>
+      <td><code>supply_fan_specific_power_w_per_m3_s</code>,
+          <code>extract_fan_specific_power_w_per_m3_s</code>,
+          <code>fan_performance_model</code>,
+          <code>*_fan_design_pressure_pa</code>,
+          <code>*_fan_nominal_efficiency</code>,
+          <code>*_fan_reference_flow_m3_h</code>,
+          <code>*_fan_reference_efficiency</code></td>
+      <td>0, <code>"en16798_5_1"</code>, derived, 0.72 / 0.78, design values</td>
+      <td>Nominal specific fan power at design flow plus optional product data
+          for the part-load relations.</td>
+    </tr>
+    <tr>
+      <td>Fan heat to air</td>
+      <td><code>supply_fan_heat_fraction_to_air</code>,
+          <code>extract_fan_heat_fraction_to_air</code></td>
+      <td>0.90 / 0.90</td>
+      <td>Share of fan electricity heating the respective airstream.</td>
+    </tr>
+    <tr>
+      <td>Operating schedule</td>
+      <td><code>profile</code> (names a profile column)</td>
+      <td>1.0</td>
+      <td>Continuous flow fraction in [0, 1] relative to design flow
+          (reduced flow, not duty cycle).</td>
+    </tr>
+  </table>
+
+  <h2>Calculation Mapping</h2>
+  <table>
+    <tr><th>Standard framework item</th><th>Implemented calculation</th><th>Code location</th><th>Output fields</th></tr>
+    <tr>
+      <td>Supply-temperature controller (Table B.2 framework)</td>
+      <td>Resolves the requested setpoint from fixed value, schedule, or
+          piecewise-linear compensation curve before the thermodynamic step.</td>
+      <td><code>resolve_supply_temperature_setpoint()</code>,
+          <code>SupplyTemperatureControl</code></td>
+      <td><code>requested_supply_temperature_c</code></td>
+    </tr>
+    <tr>
+      <td>Fan power and air heat-up (single-zone no-control relations,
+          product-data efficiency correction)</td>
+      <td>Design pressure from nominal SFP and efficiency unless given;
+          part-load pressure with the square of the flow ratio; efficiency with
+          the square-root flow correction; temperature rise from heat fraction
+          to air.</td>
+      <td><code>_fan_power_and_temperature_rise()</code></td>
+      <td><code>fan_electric_power_w</code></td>
+    </tr>
+    <tr>
+      <td>Frost protection, direct effectiveness control (cf. formula (46))</td>
+      <td>Reduces effective heat-recovery efficiency so the exhaust at the
+          recovery outlet stays at or above the configured limit.</td>
+      <td><code>calculate_sensible_ahu_step()</code> step 4</td>
+      <td><code>frost_protection_required</code></td>
+    </tr>
+    <tr>
+      <td>Sensible heat recovery and bypass modulation</td>
+      <td>Recovery outlet temperature from effectiveness; modulating bypass
+          mixes outdoor air to track the setpoint; recovery power is the net
+          supply-side gain relative to outdoor air (matches the formula (77)
+          bookkeeping only under balanced flow, no recirculation, no outdoor-air
+          preheat and inactive frost correction).</td>
+      <td><code>calculate_sensible_ahu_step()</code> steps 5-7</td>
+      <td><code>heat_recovery_power_w</code>, <code>bypass_fraction</code></td>
+    </tr>
+    <tr>
+      <td>Sensible cooling coil</td>
+      <td>Required power to pull post-recovery air down to the target;
+          delivered power limited by enable flag and capacity. Precedes the
+          heating coil in the air path.</td>
+      <td><code>calculate_sensible_ahu_step()</code> step 8a</td>
+      <td><code>required_cooling_coil_power_w</code>,
+          <code>actual_cooling_coil_power_w</code></td>
+    </tr>
+    <tr>
+      <td>Sensible heating coil</td>
+      <td>Required power to raise air to the fan-heat-adjusted target;
+          delivered power limited by capacity.</td>
+      <td><code>calculate_sensible_ahu_step()</code> step 8b</td>
+      <td><code>required_heating_coil_power_w</code>,
+          <code>actual_heating_coil_power_w</code></td>
+    </tr>
+    <tr>
+      <td>Zone coupling (ISO 52016-1 &sect;6.5.10)</td>
+      <td>Supply stream conductance and source temperature from delivered flow
+          and temperature; zero flow yields zero conductance.</td>
+      <td><code>ahu_outputs_to_ventilation_stream()</code>,
+          <code>ventilation.py::_resolve_component_streams()</code></td>
+      <td><code>actual_supply_temperature_c</code>,
+          <code>actual_supply_flow_m3_h</code></td>
+    </tr>
+  </table>
+
+  <h2>Output Diagnostics</h2>
+  <p>
+    When at least one <code>mechanical_supply</code> component runs, twelve
+    diagnostic columns per component are added to the hourly results. The
+    single-zone solver paths suffix columns with the component name
+    (<code>Q_ahu_coil_&lt;component&gt;</code>); the multizone path also appends
+    the zone name (<code>Q_ahu_coil_&lt;component&gt;_&lt;zone&gt;</code>).
+  </p>
+  <table>
+    <tr><th>Column prefix</th><th>Quantity</th><th>Unit</th></tr>
+    <tr><td><code>Q_ahu_coil</code> / <code>Q_ahu_coil_req</code></td><td>Delivered / required heating-coil power (timestep average)</td><td>W</td></tr>
+    <tr><td><code>Q_ahu_cool</code> / <code>Q_ahu_cool_req</code></td><td>Delivered / required sensible cooling-coil power</td><td>W</td></tr>
+    <tr><td><code>Q_ahu_hr</code></td><td>Heat-recovery power (negative in economizer operation)</td><td>W</td></tr>
+    <tr><td><code>P_ahu_fan</code></td><td>Total fan electric power</td><td>W</td></tr>
+    <tr><td><code>T_ahu_sup</code> / <code>T_ahu_sup_req</code></td><td>Delivered / requested supply temperature (requested is NaN when the AHU is off)</td><td>&deg;C</td></tr>
+    <tr><td><code>q_sup_m3h</code> / <code>q_ext_m3h</code></td><td>Actual supply / extract airflow</td><td>m&sup3;/h</td></tr>
+    <tr><td><code>ahu_bypass</code></td><td>Effective bypass fraction (frost plus modulation)</td><td>-</td></tr>
+    <tr><td><code>ahu_frost</code></td><td>Frost protection active (0/1)</td><td>-</td></tr>
+  </table>
+
+  <div class="note">
+    <strong>Energy bookkeeping.</strong> AHU coil energy is reported as a
+    system-side diagnostic and is deliberately <em>not</em> added to the zone
+    energy balance (Sankey): the zone ventilation term already uses the
+    conditioned supply temperature, so adding coil energy on the zone side
+    would double-count it. Required-minus-delivered coil power exposes unmet
+    AHU demand.
+  </div>
+
+  <h2>Validation Status</h2>
+  <ul>
+    <li>Analytical unit tests derive expected values from first-principles
+        sensible heat balances with independently defined air properties
+        (heat-recovery balance, bypass mixing, frost limit, coil limits and
+        shortfall reporting, fan power and fan-heat placement).</li>
+    <li>The fan part-load pressure and efficiency relations follow the
+        EPB Center EN 16798-5-1 reference implementation for the overlapping
+        single-zone fan and sensible-air calculations.</li>
+    <li>Integration tests cover the coupling into the affine ventilation
+        boundary and the end-to-end solver paths (legacy, causal and
+        multizone), including the lagged extract-air assumption and the
+        diagnostic column schema.</li>
+  </ul>
+
+  <div class="note">
+    This module evaluates and demonstrates the calculation approach of
+    EN 16798-5-1 for a sensible, balanced-airflow subset. It does not replace
+    the standard and should be used alongside it. Defaults documented above
+    (fan efficiencies, fan heat fractions, frost limit) are placeholders for
+    product and design data and should be replaced with project values.
+  </div>
+</body>
+</html>

--- a/src/pybuildingenergy/source/utils.py
+++ b/src/pybuildingenergy/source/utils.py
@@ -3873,6 +3873,11 @@ class ISO52016:
                 }
             )
 
+        # Per-zone AHU output buffers: keyed by (zone_index, component_name).
+        # Populated lazily on first encounter so unknown component sets don't need pre-scanning.
+        # Keys: "Q_coil" [W actual], "Q_hr" [W], "P_fan" [W], "T_sup" [°C], "frost" [0/1].
+        _ahu_buffers: dict = {}  # (zi, comp_name) -> {"Q_coil": np.array, ...}
+
         # ------------------------
         # 7) Ground virtual temperature (optional)
         # ------------------------
@@ -4217,10 +4222,11 @@ class ISO52016:
             theta_air_prev: float,
             tstep: int,
             T_out: float,
-        ) -> tuple:  # (VentilationBoundary, float, int)
+        ) -> tuple:  # (VentilationBoundary, float, int, dict)
             _empty = VentilationBoundary(streams=())
+            _empty_ahu: dict = {}
             if not include_ventilation:
-                return _empty, 1.0, 0
+                return _empty, 1.0, 0, _empty_ahu
 
             zname = str(zone_obj.get("name", zone_names[0]))
             if zname not in zone_proxies:
@@ -4232,7 +4238,7 @@ class ISO52016:
             has_components = "components" in vent_cfg
 
             if not has_components and vent_type in ("none", "off", "disabled", ""):
-                return _empty, 1.0, 0
+                return _empty, 1.0, 0, _empty_ahu
 
             ws = float(sim_df["WS10m"].iloc[tstep]) if "WS10m" in sim_df.columns else 0.0
             profile_mult = _profile_value(zname, "ventilation_profile", tstep, 1.0)
@@ -4274,6 +4280,7 @@ class ISO52016:
                         )
                     _comp_mult[_cname] = _profile_value(zname, _prof, tstep, 1.0)
 
+            _ahu_coll: dict = {}
             try:
                 base_bdy = resolve_ventilation_boundary(
                     proxy,
@@ -4283,6 +4290,7 @@ class ISO52016:
                     profile_multiplier=profile_mult,
                     component_multipliers=_comp_mult if _comp_mult else None,
                     zone_volume_m3=zone_vol if zone_vol > 0.0 else None,
+                    ahu_outputs_collector=_ahu_coll,
                 )
             except Exception as exc:
                 raise RuntimeError(
@@ -4395,7 +4403,7 @@ class ISO52016:
                         purge_factor_applied = float(boost_factor)
                         purge_active = 1
 
-            return base_bdy, purge_factor_applied, purge_active
+            return base_bdy, purge_factor_applied, purge_active, _ahu_coll
 
         def _zone_solar_transmitted_w(tstep: int) -> np.ndarray:
             phi_sol = np.zeros(Z, dtype=float)
@@ -4720,11 +4728,27 @@ class ISO52016:
             purge_active_z_t = np.zeros(Z, dtype=int)
             for zi, zone in enumerate(zones):
                 phi_int_z_t[zi] = _zone_internal_gain_w(zone, t)
-                vent_bdy, purge_factor_z_t[zi], purge_active_z_t[zi] = _zone_ventilation_h_wk(
-                    zone, Theta[zi], t, T_out
+                vent_bdy, purge_factor_z_t[zi], purge_active_z_t[zi], _ahu_step = (
+                    _zone_ventilation_h_wk(zone, Theta[zi], t, T_out)
                 )
                 h_ve_z_t[zi] = vent_bdy.heat_transfer_coefficient_w_k
                 s_ve_z_t[zi] = vent_bdy.source_term_w
+                for _cn, _ao in _ahu_step.items():
+                    _key = (zi, _cn)
+                    if _key not in _ahu_buffers:
+                        _ahu_buffers[_key] = {
+                            "Q_coil": np.full(Tstepn, np.nan),
+                            "Q_hr": np.full(Tstepn, np.nan),
+                            "P_fan": np.full(Tstepn, np.nan),
+                            "T_sup": np.full(Tstepn, np.nan),
+                            "frost": np.zeros(Tstepn, dtype=np.int8),
+                        }
+                    _buf = _ahu_buffers[_key]
+                    _buf["Q_coil"][t] = _ao.actual_heating_coil_power_w
+                    _buf["Q_hr"][t] = _ao.heat_recovery_power_w
+                    _buf["P_fan"][t] = _ao.fan_electric_power_w
+                    _buf["T_sup"][t] = _ao.actual_supply_temperature_c
+                    _buf["frost"][t] = int(_ao.frost_protection_required)
             phi_sol_z_t = _zone_solar_transmitted_w(t)
 
             # Base matrix for this timestep
@@ -4938,6 +4962,16 @@ class ISO52016:
             out_data[f"Q_ground_surface_{surface_out['surface_token']}"] = surface_out["Q_ground"]
         for surface_out in opaque_inside_surface_output_buffers:
             out_data[f"Q_opaque_inside_surface_{surface_out['surface_token']}"] = surface_out["Q_inside"]
+
+        # AHU component outputs: Q_ahu_coil, Q_ahu_hr, P_ahu_fan, T_ahu_sup, ahu_frost
+        # Columns appear only when at least one mechanical_supply component ran.
+        for (zi, comp_name), _buf in _ahu_buffers.items():
+            _zn = zone_names[zi]
+            out_data[f"Q_ahu_coil_{comp_name}_{_zn}"] = _buf["Q_coil"]
+            out_data[f"Q_ahu_hr_{comp_name}_{_zn}"] = _buf["Q_hr"]
+            out_data[f"P_ahu_fan_{comp_name}_{_zn}"] = _buf["P_fan"]
+            out_data[f"T_ahu_sup_{comp_name}_{_zn}"] = _buf["T_sup"]
+            out_data[f"ahu_frost_{comp_name}_{_zn}"] = _buf["frost"]
 
         out = pd.DataFrame(out_data, index=sim_df.index)
         out = out.iloc[start_idx:].copy()

--- a/src/pybuildingenergy/source/utils.py
+++ b/src/pybuildingenergy/source/utils.py
@@ -211,6 +211,7 @@ def _ahu_coll_to_columns(ahu_coll_act):
 
         cols[f"Q_ahu_coil{sfx}"]     = _arr("actual_heating_coil_power_w")
         cols[f"Q_ahu_coil_req{sfx}"] = _arr("required_heating_coil_power_w")
+        cols[f"Q_ahu_cool{sfx}"]     = _arr("actual_cooling_coil_power_w")
         cols[f"Q_ahu_cool_req{sfx}"] = _arr("required_cooling_coil_power_w")
         cols[f"Q_ahu_hr{sfx}"]       = _arr("heat_recovery_power_w")
         cols[f"P_ahu_fan{sfx}"]      = _arr("fan_electric_power_w")

--- a/src/pybuildingenergy/source/utils.py
+++ b/src/pybuildingenergy/source/utils.py
@@ -179,15 +179,33 @@ def _resolve_single_zone_vent_boundary(
     )
 
 
+# Ordered specification of AHU diagnostic output fields: (column_prefix, attribute_name, dtype).
+# Used by both _ahu_coll_to_columns (legacy/causal paths) and the multizone buffer, so that
+# all solver paths expose the same 12 diagnostic columns.
+# AHU coil energy must NOT be added to the zone Sankey — the ventilation term already uses
+# the conditioned supply temperature, so adding coil energy would double-count.
+_AHU_DIAG_SPEC: tuple = (
+    ("Q_ahu_coil",     "actual_heating_coil_power_w",    float),
+    ("Q_ahu_coil_req", "required_heating_coil_power_w",  float),
+    ("Q_ahu_cool",     "actual_cooling_coil_power_w",    float),
+    ("Q_ahu_cool_req", "required_cooling_coil_power_w",  float),
+    ("Q_ahu_hr",       "heat_recovery_power_w",          float),
+    ("P_ahu_fan",      "fan_electric_power_w",           float),
+    ("T_ahu_sup",      "actual_supply_temperature_c",    float),
+    ("T_ahu_sup_req",  "requested_supply_temperature_c", float),
+    ("q_sup_m3h",      "actual_supply_flow_m3_h",        float),
+    ("q_ext_m3h",      "actual_extract_flow_m3_h",       float),
+    ("ahu_bypass",     "bypass_fraction",                float),
+    ("ahu_frost",      "frost_protection_required",      int),
+)
+
+
 def _ahu_coll_to_columns(ahu_coll_act):
     """Convert per-timestep {component_name: AHUStepOutputs} dicts to hourly column arrays.
 
     Returns {col_name: np.array} for all mechanical_supply components found in the list.
     Only called when at least one such component is present.
-
-    AHU coil energy is NOT added to the zone Sankey.  Adding it would conflict
-    with the zone-boundary energy balance, because the ventilation loss term
-    already uses the conditioned supply temperature.
+    Column schema is defined by _AHU_DIAG_SPEC — identical to the multizone path.
     """
     names = sorted({k for d in ahu_coll_act for k in d})
     if not names:
@@ -198,29 +216,15 @@ def _ahu_coll_to_columns(ahu_coll_act):
     for name in names:
         sfx = f"_{name}"
         vv = [d.get(name) for d in ahu_coll_act]
-
-        def _arr(attr, _vv=vv, dtype=float):
+        for col_pfx, attr, dtype in _AHU_DIAG_SPEC:
             a = np.empty(n, dtype=dtype)
-            for i, v in enumerate(_vv):
+            for i, v in enumerate(vv):
                 raw = getattr(v, attr) if v is not None else None
                 if dtype == float:
                     a[i] = float(raw) if raw is not None else np.nan
                 else:
                     a[i] = int(bool(raw)) if raw is not None else 0
-            return a
-
-        cols[f"Q_ahu_coil{sfx}"]     = _arr("actual_heating_coil_power_w")
-        cols[f"Q_ahu_coil_req{sfx}"] = _arr("required_heating_coil_power_w")
-        cols[f"Q_ahu_cool{sfx}"]     = _arr("actual_cooling_coil_power_w")
-        cols[f"Q_ahu_cool_req{sfx}"] = _arr("required_cooling_coil_power_w")
-        cols[f"Q_ahu_hr{sfx}"]       = _arr("heat_recovery_power_w")
-        cols[f"P_ahu_fan{sfx}"]      = _arr("fan_electric_power_w")
-        cols[f"T_ahu_sup{sfx}"]      = _arr("actual_supply_temperature_c")
-        cols[f"T_ahu_sup_req{sfx}"]  = _arr("requested_supply_temperature_c")
-        cols[f"q_sup_m3h{sfx}"]      = _arr("actual_supply_flow_m3_h")
-        cols[f"q_ext_m3h{sfx}"]      = _arr("actual_extract_flow_m3_h")
-        cols[f"ahu_bypass{sfx}"]     = _arr("bypass_fraction")
-        cols[f"ahu_frost{sfx}"]      = _arr("frost_protection_required", dtype=int)
+            cols[f"{col_pfx}{sfx}"] = a
     return cols
 
 
@@ -3928,9 +3932,9 @@ class ISO52016:
             )
 
         # Per-zone AHU output buffers: keyed by (zone_index, component_name).
-        # Populated lazily on first encounter so unknown component sets don't need pre-scanning.
-        # Keys: "Q_coil" [W actual], "Q_hr" [W], "P_fan" [W], "T_sup" [°C], "frost" [0/1].
-        _ahu_buffers: dict = {}  # (zi, comp_name) -> {"Q_coil": np.array, ...}
+        # Populated lazily on first encounter. Keys are the _AHU_DIAG_SPEC column prefixes,
+        # so the multizone output schema matches _ahu_coll_to_columns (legacy/causal paths).
+        _ahu_buffers: dict = {}  # (zi, comp_name) -> {col_pfx: np.array}
 
         # ------------------------
         # 7) Ground virtual temperature (optional)
@@ -4782,6 +4786,8 @@ class ISO52016:
             purge_active_z_t = np.zeros(Z, dtype=int)
             for zi, zone in enumerate(zones):
                 phi_int_z_t[zi] = _zone_internal_gain_w(zone, t)
+                # Theta[zi] is the zone AIR node (first Z rows of state vector),
+                # not the operative temperature — explicit lag, no algebraic loop.
                 vent_bdy, purge_factor_z_t[zi], purge_active_z_t[zi], _ahu_step = (
                     _zone_ventilation_h_wk(zone, Theta[zi], t, T_out)
                 )
@@ -4791,18 +4797,19 @@ class ISO52016:
                     _key = (zi, _cn)
                     if _key not in _ahu_buffers:
                         _ahu_buffers[_key] = {
-                            "Q_coil": np.full(Tstepn, np.nan),
-                            "Q_hr": np.full(Tstepn, np.nan),
-                            "P_fan": np.full(Tstepn, np.nan),
-                            "T_sup": np.full(Tstepn, np.nan),
-                            "frost": np.zeros(Tstepn, dtype=np.int8),
+                            col_pfx: (
+                                np.full(Tstepn, np.nan, dtype=float) if dtype == float
+                                else np.zeros(Tstepn, dtype=dtype)
+                            )
+                            for col_pfx, _, dtype in _AHU_DIAG_SPEC
                         }
                     _buf = _ahu_buffers[_key]
-                    _buf["Q_coil"][t] = _ao.actual_heating_coil_power_w
-                    _buf["Q_hr"][t] = _ao.heat_recovery_power_w
-                    _buf["P_fan"][t] = _ao.fan_electric_power_w
-                    _buf["T_sup"][t] = _ao.actual_supply_temperature_c
-                    _buf["frost"][t] = int(_ao.frost_protection_required)
+                    for col_pfx, attr, dtype in _AHU_DIAG_SPEC:
+                        raw = getattr(_ao, attr)
+                        if dtype == float:
+                            _buf[col_pfx][t] = float(raw) if raw is not None else np.nan
+                        else:
+                            _buf[col_pfx][t] = int(bool(raw))
             phi_sol_z_t = _zone_solar_transmitted_w(t)
 
             # Base matrix for this timestep
@@ -5017,15 +5024,14 @@ class ISO52016:
         for surface_out in opaque_inside_surface_output_buffers:
             out_data[f"Q_opaque_inside_surface_{surface_out['surface_token']}"] = surface_out["Q_inside"]
 
-        # AHU component outputs: Q_ahu_coil, Q_ahu_hr, P_ahu_fan, T_ahu_sup, ahu_frost
+        # AHU component diagnostics — 12 fields per component (from _AHU_DIAG_SPEC).
+        # Column names: {col_pfx}_{comp_name}_{zone_name}.  Same field set as the
+        # legacy/causal paths (_ahu_coll_to_columns), different suffix convention.
         # Columns appear only when at least one mechanical_supply component ran.
         for (zi, comp_name), _buf in _ahu_buffers.items():
             _zn = zone_names[zi]
-            out_data[f"Q_ahu_coil_{comp_name}_{_zn}"] = _buf["Q_coil"]
-            out_data[f"Q_ahu_hr_{comp_name}_{_zn}"] = _buf["Q_hr"]
-            out_data[f"P_ahu_fan_{comp_name}_{_zn}"] = _buf["P_fan"]
-            out_data[f"T_ahu_sup_{comp_name}_{_zn}"] = _buf["T_sup"]
-            out_data[f"ahu_frost_{comp_name}_{_zn}"] = _buf["frost"]
+            for col_pfx, _, _ in _AHU_DIAG_SPEC:
+                out_data[f"{col_pfx}_{comp_name}_{_zn}"] = _buf[col_pfx]
 
         out = pd.DataFrame(out_data, index=sim_df.index)
         out = out.iloc[start_idx:].copy()

--- a/src/pybuildingenergy/source/utils.py
+++ b/src/pybuildingenergy/source/utils.py
@@ -131,13 +131,21 @@ def _make_sched_resolver(kwargs, iso16798_profiles_obj):
     return _sched
 
 
-def _resolve_single_zone_vent_boundary(building_object, T_zone, Tstepi, sim_df, profile_df):
+def _resolve_single_zone_vent_boundary(
+    building_object, T_zone, Tstepi, sim_df, profile_df,
+    ahu_outputs_collector=None,
+):
     """Build the affine ventilation boundary for legacy and causal single-zone solvers.
 
     Reads zone volume and ventilation config from *building_object*, resolves per-component
     profile multipliers from *profile_df* at timestep *Tstepi*, and delegates to
     resolve_ventilation_boundary.  Centralises logic that is otherwise duplicated in the
     legacy and causal solver timestep loops.
+
+    When *ahu_outputs_collector* is a dict it is passed through to
+    resolve_ventilation_boundary → _resolve_component_streams, which will write
+    {component_name: AHUStepOutputs} entries for every mechanical_supply component.
+    The caller is responsible for snapshotting the dict after each timestep.
     """
     _bld = building_object.get("building", {})
     _zone_vol = float(
@@ -167,7 +175,52 @@ def _resolve_single_zone_vent_boundary(building_object, T_zone, Tstepi, sim_df, 
         profile_multiplier=float(profile_df["ventilation_profile"].iloc[Tstepi]),
         component_multipliers=_comp_mult if _comp_mult else None,
         zone_volume_m3=_zone_vol if _zone_vol > 0.0 else None,
+        ahu_outputs_collector=ahu_outputs_collector,
     )
+
+
+def _ahu_coll_to_columns(ahu_coll_act):
+    """Convert per-timestep {component_name: AHUStepOutputs} dicts to hourly column arrays.
+
+    Returns {col_name: np.array} for all mechanical_supply components found in the list.
+    Only called when at least one such component is present.
+
+    AHU coil energy is NOT added to the zone Sankey.  Adding it would conflict
+    with the zone-boundary energy balance, because the ventilation loss term
+    already uses the conditioned supply temperature.
+    """
+    names = sorted({k for d in ahu_coll_act for k in d})
+    if not names:
+        return {}
+
+    cols: dict = {}
+    n = len(ahu_coll_act)
+    for name in names:
+        sfx = f"_{name}"
+        vv = [d.get(name) for d in ahu_coll_act]
+
+        def _arr(attr, _vv=vv, dtype=float):
+            a = np.empty(n, dtype=dtype)
+            for i, v in enumerate(_vv):
+                raw = getattr(v, attr) if v is not None else None
+                if dtype == float:
+                    a[i] = float(raw) if raw is not None else np.nan
+                else:
+                    a[i] = int(bool(raw)) if raw is not None else 0
+            return a
+
+        cols[f"Q_ahu_coil{sfx}"]     = _arr("actual_heating_coil_power_w")
+        cols[f"Q_ahu_coil_req{sfx}"] = _arr("required_heating_coil_power_w")
+        cols[f"Q_ahu_cool_req{sfx}"] = _arr("required_cooling_coil_power_w")
+        cols[f"Q_ahu_hr{sfx}"]       = _arr("heat_recovery_power_w")
+        cols[f"P_ahu_fan{sfx}"]      = _arr("fan_electric_power_w")
+        cols[f"T_ahu_sup{sfx}"]      = _arr("actual_supply_temperature_c")
+        cols[f"T_ahu_sup_req{sfx}"]  = _arr("requested_supply_temperature_c")
+        cols[f"q_sup_m3h{sfx}"]      = _arr("actual_supply_flow_m3_h")
+        cols[f"q_ext_m3h{sfx}"]      = _arr("actual_extract_flow_m3_h")
+        cols[f"ahu_bypass{sfx}"]     = _arr("bypass_fraction")
+        cols[f"ahu_frost{sfx}"]      = _arr("frost_protection_required", dtype=int)
+    return cols
 
 
 def _infer_timestep_hours_from_index(index, default=1.0):
@@ -6484,6 +6537,7 @@ class ISO52016:
         """
         H_ve_nat_all = [0]
         S_ve_nat_all = [0.0]
+        _ahu_coll_all: list = []   # per-timestep {comp_name: AHUStepOutputs}; appended once per timestep after HVAC loop
         # Time step for indoor temperature in adjacent zones
         if building_object['building']['adj_zones_present']:
             list_adj_zones = building_object['building']['number_adj_zone']
@@ -6734,6 +6788,7 @@ class ISO52016:
                 iterate = True
                 _H_ve_nat_tstep = 0.0
                 _S_ve_nat_tstep = 0.0
+                _ahu_coll_tstep: dict = {}   # overwritten each while iteration; final value captured after loop
                 while iterate:
 
                     iterate = False
@@ -6803,6 +6858,7 @@ class ISO52016:
 
                     _vent_bdy = _resolve_single_zone_vent_boundary(
                         building_object, float(Theta_old[ri]), Tstepi, sim_df, profile_df,
+                        ahu_outputs_collector=_ahu_coll_tstep,
                     )
                     H_ve_nat = _vent_bdy.heat_transfer_coefficient_w_k
                     S_ve_nat = _vent_bdy.source_term_w
@@ -7213,6 +7269,7 @@ class ISO52016:
                 # while loop so HVAC re-solving iterations do not duplicate entries).
                 H_ve_nat_all.append(_H_ve_nat_tstep)
                 S_ve_nat_all.append(_S_ve_nat_tstep)
+                _ahu_coll_all.append(dict(_ahu_coll_tstep))
                 H_ve_nat = _H_ve_nat_tstep
                 S_ve_nat = _S_ve_nat_tstep
 
@@ -7388,6 +7445,12 @@ class ISO52016:
         )
         hourly_results["T_ve_source_eq"] = _t_eq
         hourly_results["Q_ve"] = _h_ve_arr * _t_air_arr - _s_ve_arr
+
+        # AHU per-component diagnostics — only populated when mechanical_supply
+        # components are present. NOT added to the Sankey: AHU coil heat crosses
+        # the zone boundary from the system side and must not double-count Q_HC.
+        for _col_name, _col_arr in _ahu_coll_to_columns(_ahu_coll_all[act_slice]).items():
+            hourly_results[_col_name] = _col_arr
 
         # separate H/C
         hourly_results["Q_H"] = 0.0
@@ -7912,6 +7975,7 @@ class ISO52016:
         """
         H_ve_nat_all = [0]
         S_ve_nat_all = [0.0]
+        _ahu_coll_all: list = []   # per-timestep {comp_name: AHUStepOutputs}; appended once per timestep after HVAC loop
         # Time step for indoor temperature in adjacent zones
         if building_object['building']['adj_zones_present']:
             list_adj_zones = building_object['building']['number_adj_zone']
@@ -8210,6 +8274,7 @@ class ISO52016:
                 iterate = True
                 _H_ve_nat_tstep = 0.0
                 _S_ve_nat_tstep = 0.0
+                _ahu_coll_tstep: dict = {}   # overwritten each while iteration; final value captured after loop
                 while iterate:
 
                     iterate = False
@@ -8279,6 +8344,7 @@ class ISO52016:
 
                     _vent_bdy = _resolve_single_zone_vent_boundary(
                         building_object, float(Theta_old[ri]), Tstepi, sim_df, profile_df,
+                        ahu_outputs_collector=_ahu_coll_tstep,
                     )
                     H_ve_nat = _vent_bdy.heat_transfer_coefficient_w_k
                     S_ve_nat = _vent_bdy.source_term_w
@@ -8726,6 +8792,7 @@ class ISO52016:
                 # while loop so HVAC re-solving iterations do not duplicate entries).
                 H_ve_nat_all.append(_H_ve_nat_tstep)
                 S_ve_nat_all.append(_S_ve_nat_tstep)
+                _ahu_coll_all.append(dict(_ahu_coll_tstep))
                 H_ve_nat = _H_ve_nat_tstep
                 S_ve_nat = _S_ve_nat_tstep
 
@@ -8906,6 +8973,12 @@ class ISO52016:
         )
         hourly_results["T_ve_source_eq"] = _t_eq
         hourly_results["Q_ve"] = _h_ve_arr * _t_air_arr - _s_ve_arr
+
+        # AHU per-component diagnostics — only populated when mechanical_supply
+        # components are present. NOT added to the Sankey: AHU coil heat crosses
+        # the zone boundary from the system side and must not double-count Q_HC.
+        for _col_name, _col_arr in _ahu_coll_to_columns(_ahu_coll_all[act_slice]).items():
+            hourly_results[_col_name] = _col_arr
 
         # separate H/C
         hourly_results["Q_H"] = 0.0

--- a/src/pybuildingenergy/source/ventilation.py
+++ b/src/pybuildingenergy/source/ventilation.py
@@ -35,7 +35,7 @@ independent streams with per-component operation schedules.
 To integrate (deferred):
 - Detailed leakage and duct networks
 - Cross-ventilation and inter-zone airflow
-- Full mechanical ventilation via EN 16798-5-1 AHU module (PR 2)
+- Latent AHU processes, recirculation, duct losses, and unbalanced flow
 '''
 
 from dataclasses import dataclass
@@ -678,13 +678,20 @@ def _resolve_component_streams(
     - 'mechanical_supply': physics-based AHU step via EN 16798-5-1 sensible model.
       Requires supply_flow_m3_h, sensible_heat_recovery_efficiency,
       supply_temperature_setpoint_c. zone_temperature_c is used as the extract
-      temperature (one-step lag: T_zone from previous timestep).
+      temperature (previous-timestep zone AIR node temperature, not operative).
 
-    component_multipliers: optional per-component name -> float operation fraction.
+    component_multipliers: optional per-component name -> float.
+      For 'mechanical_supply': a continuous operating-flow fraction relative to
+      design flow. It is NOT timestep duty-cycle averaging; operation_fraction is
+      always 1.0. A value of 0.25 means the AHU runs at 25% of design airflow
+      continuously, with fan power following the EN 16798-5-1 reduced-flow relation.
+      Values outside [0, 1] raise ValueError for 'mechanical_supply'.
+      For 'constant_ach' and 'prescribed': scales H_k linearly and is not
+      restricted to [0, 1]. The resulting H_k must still be finite and
+      non-negative, as enforced by VentilationStream.
     default_multiplier: applied to any component not in component_multipliers.
-    Note: infiltration components should typically use a multiplier of 1.0 so they
-    remain active when the mechanical profile is off. Pass component_multipliers
-    explicitly to give each stream an independent schedule.
+      Infiltration components typically use 1.0 so they remain active
+      independently of the mechanical ventilation schedule.
     """
     streams = []
     seen_names: set = set()
@@ -698,7 +705,7 @@ def _resolve_component_streams(
         seen_names.add(name)
 
         comp_type = str(comp.get("ventilation_type", "")).strip().lower()
-        multiplier = float(cm.get(name, default_multiplier))
+        component_fraction = float(cm.get(name, default_multiplier))
 
         if comp_type == "constant_ach":
             if zone_volume_m3 is None or float(zone_volume_m3) <= 0.0:
@@ -708,20 +715,27 @@ def _resolve_component_streams(
                 )
             ach = float(comp["air_changes_per_hour"])
             q_m3_s = ach * float(zone_volume_m3) / 3600.0
-            h_k = rho_air * c_air * q_m3_s * multiplier
+            h_k = rho_air * c_air * q_m3_s * component_fraction
             source_temp = _parse_source_temperature(
                 comp.get("source_temperature", "outdoor"), outdoor_temperature_c
             )
             category = "outdoor_air"
 
         elif comp_type == "prescribed":
-            h_k = float(comp["heat_transfer_coefficient_w_k"]) * multiplier
+            h_k = float(comp["heat_transfer_coefficient_w_k"]) * component_fraction
             source_temp = float(comp["source_temperature_c"])
             category = comp.get("category", "supply")
 
         elif comp_type == "mechanical_supply":
-            # Physics-based AHU step: lazy import so ventilation.py (PR 1) does
-            # not hard-depend on the AHU module (PR 2) at import time.
+            # Validate flow fraction here (before AHUStepInputs) so the error
+            # names the component rather than producing a generic dataclass message.
+            if not math.isfinite(component_fraction) or not (0.0 <= component_fraction <= 1.0):
+                raise ValueError(
+                    f"Component {name!r}: mechanical-supply flow fraction must be finite "
+                    f"and in [0, 1], got {component_fraction!r}"
+                )
+            # Imported lazily: the boundary module stays usable without the
+            # AHU module unless a mechanical_supply component is configured.
             from .ventilation_16798_5_1 import (  # noqa: PLC0415
                 AHUStepInputs,
                 ahu_outputs_to_ventilation_stream,
@@ -731,14 +745,17 @@ def _resolve_component_streams(
             supply_m3_h = float(comp["supply_flow_m3_h"])
             extract_m3_h = float(comp.get("extract_flow_m3_h", supply_m3_h))
             ahu_cfg = sensible_ahu_config_from_dict(comp)
+            # extract_air_temperature_c: previous-timestep zone AIR node temperature,
+            # not operative. Explicit lag avoids the T_zone→T_extract→T_supply→T_zone loop.
+            extract_air_temperature_c = zone_temperature_c
             ahu_inp = AHUStepInputs(
                 outdoor_temperature_c=outdoor_temperature_c,
-                extract_temperature_c=zone_temperature_c,  # one-step lag
+                extract_temperature_c=extract_air_temperature_c,
                 required_supply_flow_m3_h=supply_m3_h,
                 required_extract_flow_m3_h=extract_m3_h,
                 operation_fraction=1.0,
-                timestep_hours=1.0,
-                flow_fraction=multiplier,
+                # component_fraction is a continuous flow fraction, not timestep duty-cycle.
+                flow_fraction=component_fraction,
             )
             ahu_out = calculate_sensible_ahu_step(ahu_cfg, ahu_inp)
             if ahu_outputs_collector is not None:
@@ -790,7 +807,11 @@ def resolve_ventilation_boundary(
     eplus_infiltration_ext_area, sherman_grimsrud_like) are supported via this path.
 
     profile_multiplier: operation fraction applied to the legacy single stream.
-    component_multipliers: optional dict mapping component name -> operation fraction.
+    component_multipliers: optional dict mapping component name -> float.
+      For 'mechanical_supply' components: a continuous flow fraction (not duty-cycle);
+      values outside [0, 1] raise ValueError.
+      For other component types: scales H_k linearly and is not restricted to
+      [0, 1]. The resulting H_k must still be finite and non-negative.
       Components not in the dict default to 1.0 (full capacity), so infiltration
       components remain active independently of the mechanical ventilation schedule.
       Pass {"ahu_supply": 0.0} to turn off the AHU while infiltration runs

--- a/src/pybuildingenergy/source/ventilation.py
+++ b/src/pybuildingenergy/source/ventilation.py
@@ -666,6 +666,7 @@ def _resolve_component_streams(
     rho_air: float,
     component_multipliers: dict = None,
     default_multiplier: float = 1.0,
+    zone_temperature_c: float = 20.0,
 ) -> list:
     """Convert a ventilation components list to VentilationStream objects.
 
@@ -673,6 +674,10 @@ def _resolve_component_streams(
     - 'constant_ach': infiltration or natural ventilation via air-change rate.
       Requires zone_volume_m3. source_temperature defaults to "outdoor".
     - 'prescribed': fixed H_k and source temperature supplied by caller (e.g. AHU).
+    - 'mechanical_supply': physics-based AHU step via EN 16798-5-1 sensible model.
+      Requires supply_flow_m3_h, sensible_heat_recovery_efficiency,
+      supply_temperature_setpoint_c. zone_temperature_c is used as the extract
+      temperature (one-step lag: T_zone from previous timestep).
 
     component_multipliers: optional per-component name -> float operation fraction.
     default_multiplier: applied to any component not in component_multipliers.
@@ -713,10 +718,36 @@ def _resolve_component_streams(
             source_temp = float(comp["source_temperature_c"])
             category = comp.get("category", "supply")
 
+        elif comp_type == "mechanical_supply":
+            # Physics-based AHU step: lazy import so ventilation.py (PR 1) does
+            # not hard-depend on the AHU module (PR 2) at import time.
+            from .ventilation_16798_5_1 import (  # noqa: PLC0415
+                AHUStepInputs,
+                ahu_outputs_to_ventilation_stream,
+                calculate_sensible_ahu_step,
+                sensible_ahu_config_from_dict,
+            )
+            supply_m3_h = float(comp["supply_flow_m3_h"])
+            extract_m3_h = float(comp.get("extract_flow_m3_h", supply_m3_h))
+            ahu_cfg = sensible_ahu_config_from_dict(comp)
+            ahu_inp = AHUStepInputs(
+                outdoor_temperature_c=outdoor_temperature_c,
+                extract_temperature_c=zone_temperature_c,  # one-step lag
+                required_supply_flow_m3_h=supply_m3_h,
+                required_extract_flow_m3_h=extract_m3_h,
+                operation_fraction=multiplier,
+                timestep_hours=1.0,
+            )
+            ahu_out = calculate_sensible_ahu_step(ahu_cfg, ahu_inp)
+            _s = ahu_outputs_to_ventilation_stream(ahu_out, name=name)
+            h_k = _s.heat_transfer_coefficient_w_k
+            source_temp = _s.source_temperature_c
+            category = "supply"
+
         else:
             raise ValueError(
                 f"Component {name!r}: unknown ventilation_type={comp_type!r}. "
-                "Supported component types: 'constant_ach', 'prescribed'."
+                "Supported component types: 'constant_ach', 'mechanical_supply', 'prescribed'."
             )
 
         streams.append(
@@ -787,6 +818,7 @@ def resolve_ventilation_boundary(
             rho_air,
             component_multipliers=component_multipliers,
             default_multiplier=1.0,
+            zone_temperature_c=zone_temperature_c,
         )
     else:
         vent_type = str(vent_cfg.get("ventilation_type", "none")).strip().lower()

--- a/src/pybuildingenergy/source/ventilation.py
+++ b/src/pybuildingenergy/source/ventilation.py
@@ -736,8 +736,9 @@ def _resolve_component_streams(
                 extract_temperature_c=zone_temperature_c,  # one-step lag
                 required_supply_flow_m3_h=supply_m3_h,
                 required_extract_flow_m3_h=extract_m3_h,
-                operation_fraction=multiplier,
+                operation_fraction=1.0,
                 timestep_hours=1.0,
+                flow_fraction=multiplier,
             )
             ahu_out = calculate_sensible_ahu_step(ahu_cfg, ahu_inp)
             if ahu_outputs_collector is not None:

--- a/src/pybuildingenergy/source/ventilation.py
+++ b/src/pybuildingenergy/source/ventilation.py
@@ -667,6 +667,7 @@ def _resolve_component_streams(
     component_multipliers: dict = None,
     default_multiplier: float = 1.0,
     zone_temperature_c: float = 20.0,
+    ahu_outputs_collector: dict = None,
 ) -> list:
     """Convert a ventilation components list to VentilationStream objects.
 
@@ -739,6 +740,8 @@ def _resolve_component_streams(
                 timestep_hours=1.0,
             )
             ahu_out = calculate_sensible_ahu_step(ahu_cfg, ahu_inp)
+            if ahu_outputs_collector is not None:
+                ahu_outputs_collector[name] = ahu_out
             _s = ahu_outputs_to_ventilation_stream(ahu_out, name=name)
             h_k = _s.heat_transfer_coefficient_w_k
             source_temp = _s.source_temperature_c
@@ -773,6 +776,7 @@ def resolve_ventilation_boundary(
     extra_streams=(),
     c_air: float = 1006.0,
     rho_air: float = 1.204,
+    ahu_outputs_collector: dict = None,
 ) -> VentilationBoundary:
     """Resolve building/zone configuration into an ISO 52016-1 VentilationBoundary.
 
@@ -819,6 +823,7 @@ def resolve_ventilation_boundary(
             component_multipliers=component_multipliers,
             default_multiplier=1.0,
             zone_temperature_c=zone_temperature_c,
+            ahu_outputs_collector=ahu_outputs_collector,
         )
     else:
         vent_type = str(vent_cfg.get("ventilation_type", "none")).strip().lower()

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -296,10 +296,10 @@ class SensibleAHUConfig:
         if self.heating_coil_max_power_w is not None:
             if (
                 not math.isfinite(self.heating_coil_max_power_w)
-                or self.heating_coil_max_power_w <= 0.0
+                or self.heating_coil_max_power_w < 0.0
             ):
                 raise ValueError(
-                    "heating_coil_max_power_w must be positive and finite when provided"
+                    "heating_coil_max_power_w must be finite and non-negative when provided"
                 )
 
         for name, value in (
@@ -388,34 +388,44 @@ class AHUStepOutputs:
     Power quantities are in watts, averaged over the timestep. Energy for a
     timestep is power_w * timestep_hours / 1000 kWh.
 
-    requested_supply_temperature_c: setpoint from the supply-temperature controller.
+    requested_supply_temperature_c: setpoint from the supply-temperature controller,
+                                    or None when the AHU is off (flow = 0).
     actual_supply_temperature_c:    delivered supply temperature including fan heat.
     heat_recovery_power_w:          rho*cp*q*(T_hr_outlet − T_outdoor).  Equals EN 16798-5-1
                                     formula-77 Q_hr only when all of the following hold:
                                     balanced flow, no recirculation, no ODA preheating, and
                                     frost correction inactive.  During active EXHAUST_LIMIT
-                                    frost control, this value includes what a preheat-based
-                                    defrost configuration would split into a separate preheat
-                                    term; the total supply heating from outdoor is the same
-                                    but the attribution differs.  Positive in heating mode;
-                                    negative in economizer mode.
+                                    frost control, the total supply heating relative to
+                                    outdoor air may differ from preheat-based defrost
+                                    configurations because the effective HR outlet temperature
+                                    is determined by a different algorithm.
+                                    Positive in heating mode; negative in economizer mode.
     required_heating_coil_power_w:  coil power needed to reach setpoint.
     actual_heating_coil_power_w:    coil power actually delivered (≤ required).
+    required_cooling_coil_power_w:  cooling coil power that would be needed to reach the
+                                    setpoint but cannot be delivered (cooling_coil_enabled
+                                    is not yet implemented).  Non-zero when the requested
+                                    supply temperature is below the minimum achievable by
+                                    bypass alone.
     fan_electric_power_w:           total fan electrical power (separate from thermal).
-    bypass_fraction:                fraction of airflow bypassing the HR core [0, 1].
-    frost_control_active:           True when HR efficiency was reduced for frost.
+    bypass_fraction:                effective fraction of the HR bypassed, derived from
+                                    actual vs nominal recovery [0, 1].  Reflects efficiency
+                                    reduction rather than a physical bypass damper position.
+    frost_protection_required:      True when exhaust temperature would fall below
+                                    frost_exhaust_limit_c at nominal HR efficiency.
     """
 
-    requested_supply_temperature_c: float
+    requested_supply_temperature_c: float | None
     actual_supply_temperature_c: float
     actual_supply_flow_m3_h: float
     actual_extract_flow_m3_h: float
     required_heating_coil_power_w: float
     actual_heating_coil_power_w: float
+    required_cooling_coil_power_w: float
     fan_electric_power_w: float
     heat_recovery_power_w: float
     bypass_fraction: float
-    frost_control_active: bool
+    frost_protection_required: bool
 
 
 def calculate_sensible_ahu_step(
@@ -465,16 +475,17 @@ def calculate_sensible_ahu_step(
 
     if q_sup <= 0.0:
         return AHUStepOutputs(
-            requested_supply_temperature_c=inputs.outdoor_temperature_c,
+            requested_supply_temperature_c=None,
             actual_supply_temperature_c=inputs.outdoor_temperature_c,
             actual_supply_flow_m3_h=0.0,
             actual_extract_flow_m3_h=0.0,
             required_heating_coil_power_w=0.0,
             actual_heating_coil_power_w=0.0,
+            required_cooling_coil_power_w=0.0,
             fan_electric_power_w=0.0,
             heat_recovery_power_w=0.0,
             bypass_fraction=0.0,
-            frost_control_active=False,
+            frost_protection_required=False,
         )
 
     # Step 1: Resolve requested setpoint (only reached when AHU is actually running)
@@ -506,11 +517,11 @@ def calculate_sensible_ahu_step(
     eta_nom = config.sensible_heat_recovery_efficiency
     dT = t_ext_at_hr - t_outdoor  # K; positive in heating mode
 
-    # Step 4: Bypass frost protection
+    # Step 4: EXHAUST_LIMIT frost protection (EN 16798-5-1 B108=2 INDIRECT).
     # The exhaust leaving the HR (EHA) must stay >= frost_exhaust_limit_c.
     # For balanced flow: T_EHA = T_extract_at_hr - eta * dT
-    # If T_EHA < limit, reduce eta so T_EHA exactly equals the limit.
-    frost_active = False
+    # If T_EHA < limit, reduce eta_eff so T_EHA exactly equals the limit.
+    frost_protection_req = False
     eta_eff = eta_nom
     if (
         config.frost_control is FrostControlMode.EXHAUST_LIMIT
@@ -519,7 +530,7 @@ def calculate_sensible_ahu_step(
     ):
         t_eha = t_ext_at_hr - eta_nom * dT  # exhaust at HR outlet
         if t_eha < config.frost_exhaust_limit_c:
-            frost_active = True
+            frost_protection_req = True
             eta_frost = (t_ext_at_hr - config.frost_exhaust_limit_c) / dT
             eta_eff = max(0.0, min(eta_nom, eta_frost))
 
@@ -560,6 +571,11 @@ def calculate_sensible_ahu_step(
     # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
     hr_power_w = rho_cp_q * (t_after_hr - t_outdoor)
 
+    # Unmet cooling: power that would be needed to reach t_target but cannot be
+    # delivered because no cooling coil is present.  Positive when bypass has been
+    # driven to its limit and the supply is still above the setpoint.
+    required_cooling_coil_w = rho_cp_q * max(0.0, t_after_hr - t_target)
+
     # Step 8: Heating coil targeting t_target so delivered temperature equals
     # requested_t_sup after supply fan heat is added in step 9.
     # For ON/OFF scheduling (operation_fraction < 1), the time-averaged available
@@ -588,8 +604,9 @@ def calculate_sensible_ahu_step(
         actual_extract_flow_m3_h=actual_extract_m3_h,
         required_heating_coil_power_w=required_heating_w,
         actual_heating_coil_power_w=actual_heating_w,
+        required_cooling_coil_power_w=required_cooling_coil_w,
         fan_electric_power_w=fan_electric_power_w,
         heat_recovery_power_w=hr_power_w,
         bypass_fraction=bypass_fraction,
-        frost_control_active=frost_active,
+        frost_protection_required=frost_protection_req,
     )

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -227,11 +227,12 @@ class FrostControlMode(str, Enum):
 
     NONE         — no frost protection; HR efficiency is not reduced.
     EXHAUST_LIMIT — indirect exhaust-temperature-limit control (EN 16798-5-1
-                   B108=2 "DIRECT" mode): the effective HR efficiency is
+                   B108=2 "INDIRECT" mode): the effective HR efficiency is
                    reduced continuously so the exhaust leaving the HR core
-                   stays at or above ``frost_exhaust_limit_c``.  This is
-                   equivalent to an effective partial bypass but is physically
-                   distinct from a full-bypass damper (B108=1).
+                   stays at or above ``frost_exhaust_limit_c``.  B108 selects
+                   the control method (B108=1 = DIRECT, B108=2 = INDIRECT);
+                   the defrost mechanism (bypass, preheat, recirculation) is a
+                   separate configuration dimension not represented here.
     """
 
     NONE = "none"
@@ -389,12 +390,15 @@ class AHUStepOutputs:
 
     requested_supply_temperature_c: setpoint from the supply-temperature controller.
     actual_supply_temperature_c:    delivered supply temperature including fan heat.
-    heat_recovery_power_w:          net sensible heat transferred to supply air by the HR
-                                    unit, relative to raw outdoor air: rho*cp*q*(T_hr−T_oda).
-                                    Equals EN 16798-5-1 formula-77 Q_hr for balanced flow
-                                    without recirculation or ODA preheating.  Positive in
-                                    heating mode; negative in economizer mode (ALWAYS_ON HR
-                                    or partial MODULATING_BYPASS cooling).
+    heat_recovery_power_w:          rho*cp*q*(T_hr_outlet − T_outdoor).  Equals EN 16798-5-1
+                                    formula-77 Q_hr only when all of the following hold:
+                                    balanced flow, no recirculation, no ODA preheating, and
+                                    frost correction inactive.  During active EXHAUST_LIMIT
+                                    frost control, this value includes what a preheat-based
+                                    defrost configuration would split into a separate preheat
+                                    term; the total supply heating from outdoor is the same
+                                    but the attribution differs.  Positive in heating mode;
+                                    negative in economizer mode.
     required_heating_coil_power_w:  coil power needed to reach setpoint.
     actual_heating_coil_power_w:    coil power actually delivered (≤ required).
     fan_electric_power_w:           total fan electrical power (separate from thermal).
@@ -532,14 +536,11 @@ def calculate_sensible_ahu_step(
     # Clamping handles setpoints outside the achievable mixing range: when the
     # setpoint is below T_outdoor (heating mode, no cooling), full bypass delivers
     # the closest attainable temperature; when the setpoint is above T_outdoor
-    # (economizer mode overshoot), full bypass delivers T_outdoor.
+    # (economizer mode), full bypass delivers T_outdoor.
     #
-    # Reference deviation: EN 16798-5-1 Table B.2 modes B91=2 (FIXED) and B91=3
-    # (ODA_COMP) fully bypass the HR in economizer mode (T_outdoor > T_extract),
-    # delivering T_outdoor regardless of the setpoint. Our implementation modulates
-    # to the setpoint using partial HR, which is physically more accurate. The
-    # reference LOAD_COMP mode (B91=4, closest to EXTRACT_COMPENSATED) does allow
-    # partial HR in economizer mode and aligns with our behaviour.
+    # Design choice: in economizer mode (T_outdoor > T_extract) we modulate the HR
+    # continuously to track the setpoint rather than switching to full outdoor bypass.
+    # This keeps supply delivery consistent across all conditions without a mode switch.
     if config.heat_recovery_control is HeatRecoveryControl.MODULATING_BYPASS:
         dT_hr_oda = t_after_hr - t_outdoor  # = eta_eff * dT
         if abs(dT_hr_oda) > 1e-9:

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -14,7 +14,7 @@ This is a supervisory strategy supported by the architecture of EN 16798-5-1
 but is NOT enumerated as one of the core controller modes in EN 16798-5-1
 Table B.2 (which covers fixed, outdoor-compensated, and load-compensated
 strategies). It is implemented here as a generic piecewise-linear controller
-that produces theta_SUP_req_zV for the AHU calculation.
+that produces the required supply-air temperature for the AHU calculation.
 
 Physical constants
 ------------------
@@ -231,13 +231,14 @@ class FrostControlMode(str, Enum):
     EXHAUST_LIMIT — directly reduces the effective HR efficiency so the
                    exhaust leaving the HR core stays at or above
                    ``frost_exhaust_limit_c``.  The continuous exhaust-
-                   temperature-limit formulation is mechanistically
-                   similar to EN 16798-5-1 B108=1 DIRECT (direct
-                   effectiveness control): both reduce ηhr when frost
-                   risk is present.  It differs from B108=2 INDIRECT,
-                   which adjusts the ODA preheating temperature (JODA;fp)
-                   and leaves ηhr unchanged.  B46 (defrost mechanism:
-                   bypass, preheat, recirculation) is a separate
+                   temperature-limit formulation follows the direct
+                   frost-protection approach in EN 16798-5-1 formula (46):
+                   heat-recovery efficiency is reduced when frost risk is
+                   present.  It does not implement the indirect treatment
+                   in formulas (47b) through (49), which calculates
+                   frost-protected outdoor-air and limited heat-recovery
+                   supply temperatures.  The physical defrost mechanism
+                   (bypass, preheat, or recirculation) is a separate
                    configuration dimension not modelled here.
     """
 
@@ -397,8 +398,9 @@ class AHUStepOutputs:
     requested_supply_temperature_c: setpoint from the supply-temperature controller,
                                     or None when the AHU is off (flow = 0).
     actual_supply_temperature_c:    delivered supply temperature including fan heat.
-    heat_recovery_power_w:          rho*cp*q*(T_hr_outlet − T_outdoor).  Equals EN 16798-5-1
-                                    formula-77 Q_hr only when all of the following hold:
+    heat_recovery_power_w:          rho*cp*q*(T_hr_outlet − T_outdoor).  Equals the
+                                    EN 16798-5-1 formula (77) heat-recovery term only
+                                    when all of the following hold:
                                     balanced flow, no recirculation, no ODA preheating, and
                                     frost correction inactive.  During active EXHAUST_LIMIT
                                     frost control, the total supply heating relative to
@@ -523,9 +525,9 @@ def calculate_sensible_ahu_step(
     eta_nom = config.sensible_heat_recovery_efficiency
     dT = t_ext_at_hr - t_outdoor  # K; positive in heating mode
 
-    # Step 4: EXHAUST_LIMIT frost protection — directly reduces effective HR
-    # efficiency to keep T_EHA >= frost_exhaust_limit_c (analogous to
-    # EN 16798-5-1 B108=1 DIRECT effectiveness control).
+    # Step 4: EXHAUST_LIMIT frost protection — EN 16798-5-1 formula (46)
+    # direct effectiveness control. Reduce effective HR efficiency to keep
+    # T_EHA >= frost_exhaust_limit_c.
     # The exhaust leaving the HR (EHA) must stay >= frost_exhaust_limit_c.
     # For balanced flow: T_EHA = T_extract_at_hr - eta * dT
     # If T_EHA < limit, reduce eta_eff so T_EHA exactly equals the limit.
@@ -623,6 +625,58 @@ def calculate_sensible_ahu_step(
 # ---------------------------------------------------------------------------
 # ISO 52016-1 zone adapter
 # ---------------------------------------------------------------------------
+
+def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
+    """Build a SensibleAHUConfig from a ventilation component dict.
+
+    Required keys:
+      ``sensible_heat_recovery_efficiency`` — float in [0, 1]
+      ``supply_temperature_setpoint_c``     — fixed supply setpoint [°C]
+
+    Optional keys and their defaults:
+      ``heat_recovery_control``             — "modulating_bypass"
+      ``frost_control``                     — "exhaust_limit"
+      ``frost_exhaust_limit_c``             — -5.0 [°C]
+      ``heating_coil_max_power_w``          — None (unlimited)
+      ``cooling_coil_enabled``              — False
+      ``supply_fan_specific_power_w_per_m3_s`` — 0.0
+      ``extract_fan_specific_power_w_per_m3_s`` — 0.0
+      ``supply_fan_heat_fraction_to_air``   — 1.0
+      ``extract_fan_heat_fraction_to_air``  — 1.0
+    """
+    raw_setpoint = d.get("supply_temperature_setpoint_c")
+    if raw_setpoint is None:
+        raise KeyError(
+            "mechanical_supply component requires 'supply_temperature_setpoint_c'"
+        )
+    heating_coil_max = d.get("heating_coil_max_power_w")
+    if heating_coil_max is not None:
+        heating_coil_max = float(heating_coil_max)
+    return SensibleAHUConfig(
+        sensible_heat_recovery_efficiency=float(d["sensible_heat_recovery_efficiency"]),
+        supply_temperature_control=SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.FIXED,
+            setpoint_c=float(raw_setpoint),
+        ),
+        heat_recovery_control=str(d.get("heat_recovery_control", "modulating_bypass")),
+        frost_control=str(d.get("frost_control", "exhaust_limit")),
+        frost_exhaust_limit_c=float(d.get("frost_exhaust_limit_c", -5.0)),
+        heating_coil_max_power_w=heating_coil_max,
+        cooling_coil_enabled=bool(d.get("cooling_coil_enabled", False)),
+        supply_fan_specific_power_w_per_m3_s=float(
+            d.get("supply_fan_specific_power_w_per_m3_s", 0.0)
+        ),
+        extract_fan_specific_power_w_per_m3_s=float(
+            d.get("extract_fan_specific_power_w_per_m3_s", 0.0)
+        ),
+        supply_fan_heat_fraction_to_air=float(
+            d.get("supply_fan_heat_fraction_to_air", 1.0)
+        ),
+        extract_fan_heat_fraction_to_air=float(
+            d.get("extract_fan_heat_fraction_to_air", 1.0)
+        ),
+    )
+
 
 def ahu_outputs_to_ventilation_stream(
     outputs: AHUStepOutputs,

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -256,12 +256,11 @@ class FrostControlMode(str, Enum):
 class FanPerformanceModel(str, Enum):
     """Fan power and temperature-rise calculation method.
 
-    EN16798_5_1 applies the single-zone no-control fan relations used by the
-    EN 16798-5-1 reference implementation: pressure varies with the square of
-    the flow ratio and fan efficiency follows the product-data square-root
-    correction.
+    EN16798_5_1 applies the EN 16798-5-1 single-zone no-control fan
+    relations: pressure varies with the square of the flow ratio and fan
+    efficiency follows the product-data square-root correction.
 
-    CONSTANT_SFP retains the legacy relation P = q * SFP at every flow.
+    CONSTANT_SFP applies the constant-SFP relation P = q * SFP at every flow.
     """
 
     EN16798_5_1 = "en16798_5_1"
@@ -272,7 +271,7 @@ class FanPerformanceModel(str, Enum):
 class SensibleAHUConfig:
     """Configuration for the sensible EN 16798-5-1 AHU timestep model.
 
-    Covers balanced scheduled CAV with sensible heat recovery,
+    Covers balanced single-zone airflow with sensible heat recovery,
     EXHAUST_LIMIT frost protection, modulating-bypass economizer, and
     heating and cooling coils. Cooling is sensible only (no
     dehumidification); set ``cooling_coil_enabled=True`` to deliver
@@ -292,7 +291,7 @@ class SensibleAHUConfig:
       ``delta_p = delta_p_design * (q / q_design)**2``
       ``eta = eta_ref * sqrt(q / q_ref)``
 
-      ``constant_sfp`` retains the legacy ``P = q * SFP`` relation.
+      ``constant_sfp`` applies ``P = q * SFP`` at every flow.
     """
 
     sensible_heat_recovery_efficiency: float
@@ -427,15 +426,17 @@ class AHUStepInputs:
     ``operation_fraction`` is the fraction of the timestep for which the AHU
     operates. ``flow_fraction`` is the continuous operating-flow ratio relative
     to the required/design flow. Keeping these separate distinguishes ON/OFF
-    duty averaging from true fan-speed reduction.
+    duty averaging from true fan-speed reduction. The ISO 52016 component
+    adapter maps schedules only to ``flow_fraction`` and fixes
+    ``operation_fraction`` at 1.0. Direct users of this standalone API may
+    supply a duty fraction explicitly.
     """
 
     outdoor_temperature_c: float
     extract_temperature_c: float
     required_supply_flow_m3_h: float
     required_extract_flow_m3_h: float
-    operation_fraction: float
-    timestep_hours: float
+    operation_fraction: float = 1.0
     scheduled_setpoint_c: float | None = None
     flow_fraction: float = 1.0
 
@@ -477,9 +478,6 @@ class AHUStepInputs:
         ):
             raise ValueError("flow_fraction must be finite and in [0, 1]")
 
-        if not math.isfinite(self.timestep_hours) or self.timestep_hours <= 0.0:
-            raise ValueError("timestep_hours must be positive and finite")
-
         if (
             self.scheduled_setpoint_c is not None
             and not math.isfinite(self.scheduled_setpoint_c)
@@ -491,8 +489,8 @@ class AHUStepInputs:
 class AHUStepOutputs:
     """Computed outputs for one AHU timestep.
 
-    Power quantities are in watts, averaged over the timestep. Energy for a
-    timestep is power_w * timestep_hours / 1000 kWh.
+    Power quantities are in watts, averaged over the timestep. The caller is
+    responsible for converting power to energy using its timestep duration.
 
     requested_supply_temperature_c: setpoint from the supply-temperature controller,
                                     or None when the AHU is off (flow = 0).
@@ -556,8 +554,10 @@ def _fan_power_and_temperature_rise(
 ) -> tuple[float, float]:
     """Return timestep-average fan electric power [W] and operating delta-T [K].
 
-    The EN 16798-5-1 mode follows the same pressure and fan-efficiency
-    relations as the recirc reference implementation. The temperature rise is
+    The EN 16798-5-1 mode derives the design pressure from nominal specific
+    fan power and efficiency unless given explicitly, then applies
+    ``delta_p = delta_p_design * (q / q_design)**2`` and
+    ``eta = eta_ref * sqrt(q / q_ref)`` at part load. The temperature rise is
     evaluated while the fan is operating; electric power is averaged over the
     timestep using ``operation_fraction``.
     """
@@ -615,44 +615,25 @@ def calculate_sensible_ahu_step(
 ) -> AHUStepOutputs:
     """Calculate one timestep of the sensible EN 16798-5-1 AHU model.
 
-    Calculation sequence
-    --------------------
-    1.  Scale operating flows by flow_fraction and timestep-average quantities
-        by operation_fraction. Return a zero-flow result immediately if the AHU
-        is off.
-    2.  Resolve requested supply-temperature setpoint from config controller.
-    3.  Compute fan electricity; add extract fan heat to extract before HR,
-        accumulate supply fan heat for addition after HR and coil.
-    4.  Apply EXHAUST_LIMIT frost protection: reduce effective HR efficiency
-        so the exhaust leaving the HR stays at or above frost_exhaust_limit_c.
-    5.  Compute HR outlet temperature from outdoor and frost-limited efficiency.
-    6.  Compute fan-adjusted internal coil target: subtract downstream supply fan
-        heat from requested setpoint so that delivered temperature equals requested
-        after the fan addition.  Apply modulating bypass (clamped to [0, 1]) to
-        reach internal target; full bypass yields outdoor air, no bypass yields HR
-        outlet.  Compute total bypass_fraction combining frost and modulation.
-    7.  Compute heat recovery power (net thermal gain to supply vs outdoor).
-    8a. Compute required and actual cooling-coil power; lower supply temperature
-        toward the target.  When cooling is disabled the required value reports the
-        unmet shortfall and nothing is delivered.  Cooling precedes heating in the
-        air path, per EN 16798-5-1.
-    8b. Compute required and actual heating-coil power; raise supply temperature.
-        Coil capacity applies while operating; required and delivered powers are
-        then averaged over the timestep with operation_fraction.
-    9.  Add supply fan heat to supply after the coils.
-    10. Return AHUStepOutputs with all quantities separated.
+    Air-path order: extract fan heat -> heat recovery (frost-limited
+    efficiency, modulating bypass) -> cooling coil -> heating coil ->
+    supply fan heat.  The coil target is pre-compensated for downstream
+    supply-fan heat so the delivered temperature meets the requested
+    setpoint when capacity allows.
 
-    When operation_fraction, flow_fraction, or required supply flow is zero,
-    all flow and energy outputs are zero and actual supply temperature equals
-    outdoor.
+    Power outputs are timestep averages (scaled by operation_fraction);
+    temperature outputs describe the operating airstream.  When
+    operation_fraction, flow_fraction, or required supply flow is zero, all
+    flow and energy outputs are zero and the actual supply temperature
+    equals outdoor.
     """
     if not isinstance(config, SensibleAHUConfig):
         raise TypeError("config must be a SensibleAHUConfig")
     if not isinstance(inputs, AHUStepInputs):
         raise TypeError("inputs must be an AHUStepInputs")
 
-    # Step 1: distinguish operating flow from timestep-average flow. This keeps
-    # reduced fan speed separate from ON/OFF duty averaging.
+    # Operating flow vs timestep-average flow: keeps reduced fan speed
+    # (flow_fraction) separate from ON/OFF duty averaging (operation_fraction).
     op = inputs.operation_fraction
     flow_fraction = inputs.flow_fraction
     operating_supply_m3_h = flow_fraction * inputs.required_supply_flow_m3_h
@@ -678,7 +659,7 @@ def calculate_sensible_ahu_step(
             frost_protection_required=False,
         )
 
-    # Step 1: Resolve requested setpoint (only reached when AHU is actually running)
+    # Requested setpoint (only resolved when the AHU is actually running)
     requested_t_sup = resolve_supply_temperature_setpoint(
         config.supply_temperature_control,
         inputs.outdoor_temperature_c,
@@ -688,8 +669,8 @@ def calculate_sensible_ahu_step(
 
     rho_cp_q = _RHO_CP_J_M3_K * q_sup  # W/K for supply stream
 
-    # Step 3: fan electricity and temperature rises. Power outputs are
-    # timestep averages; temperature rises describe the operating airstream.
+    # Fan electricity and temperature rises. Power outputs are timestep
+    # averages; temperature rises describe the operating airstream.
     p_sup_fan, dt_sup_fan = _fan_power_and_temperature_rise(
         model=config.fan_performance_model,
         operating_flow_m3_h=operating_supply_m3_h,
@@ -725,12 +706,10 @@ def calculate_sensible_ahu_step(
     eta_nom = config.sensible_heat_recovery_efficiency
     dT = t_ext_at_hr - t_outdoor  # K; positive in heating mode
 
-    # Step 4: EXHAUST_LIMIT frost protection — EN 16798-5-1 formula (46)
-    # direct effectiveness control. Reduce effective HR efficiency to keep
-    # T_EHA >= frost_exhaust_limit_c.
-    # The exhaust leaving the HR (EHA) must stay >= frost_exhaust_limit_c.
-    # For balanced flow: T_EHA = T_extract_at_hr - eta * dT
-    # If T_EHA < limit, reduce eta_eff so T_EHA exactly equals the limit.
+    # EXHAUST_LIMIT frost protection — EN 16798-5-1 formula (46) direct
+    # effectiveness control.  For balanced flow the exhaust leaving the HR is
+    # T_EHA = T_extract_at_hr - eta * dT; if it would fall below
+    # frost_exhaust_limit_c, reduce eta_eff so T_EHA sits exactly at the limit.
     frost_protection_req = False
     eta_eff = eta_nom
     if (
@@ -744,12 +723,11 @@ def calculate_sensible_ahu_step(
             eta_frost = (t_ext_at_hr - config.frost_exhaust_limit_c) / dT
             eta_eff = max(0.0, min(eta_nom, eta_frost))
 
-    # Step 5: HR outlet temperature (before modulation)
+    # HR outlet temperature (before bypass modulation)
     t_after_hr = t_outdoor + eta_eff * dT
 
-    # Step 6: Modulating bypass and total bypass_fraction.
-    # Internal target: subtract downstream supply fan heat so delivered temperature
-    # equals requested_t_sup after the fan addition in step 9.
+    # Internal coil/bypass target: subtract downstream supply fan heat so the
+    # delivered temperature equals requested_t_sup after the fan addition below.
     t_target = requested_t_sup - dt_sup_fan
 
     # Bypass formula: bp = (T_hr - T_target) / (T_hr - T_outdoor), clamped to [0, 1].
@@ -769,8 +747,8 @@ def calculate_sensible_ahu_step(
             bp = max(0.0, min(1.0, bp))
             t_after_hr = t_outdoor * bp + t_after_hr * (1.0 - bp)
 
-    # Total effective bypass fraction: fraction of supply air bypassing the HR core
-    # due to both frost protection (step 4) and setpoint modulation above.
+    # Total effective bypass fraction: fraction of supply air bypassing the HR
+    # core due to both frost protection and setpoint modulation.
     if eta_nom > 0.0 and abs(dT) > 1e-9:
         bypass_fraction = max(
             0.0, min(1.0, 1.0 - (t_after_hr - t_outdoor) / (eta_nom * dT))
@@ -778,16 +756,12 @@ def calculate_sensible_ahu_step(
     else:
         bypass_fraction = 0.0
 
-    # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
+    # Heat recovery power: net thermal gain of the supply stream vs outdoor air
     hr_power_operating_w = rho_cp_q * (t_after_hr - t_outdoor)
 
-    # Step 8a: Cooling coil — placed before the heating coil to follow the
-    # EN 16798-5-1 air path (the spreadsheet's cooling/dehumidification block,
-    # formulas around D111-D158, precedes the heating block at D129-D154).  In
-    # this sensible single-setpoint model the two coils are mutually exclusive
-    # within a timestep, so ordering does not change the result, but it keeps the
-    # sequence faithful to the standard and ready for a future dehumidification-
-    # reheat extension.
+    # Cooling coil — precedes the heating coil, following the EN 16798-5-1 air
+    # path.  In this sensible single-setpoint model the two coils are mutually
+    # exclusive within a timestep, so the ordering does not change the result.
     #
     # required_cooling is the sensible load needed to pull the post-HR/bypass air
     # down to t_target.  When the coil is disabled it is reported as the unmet
@@ -806,8 +780,8 @@ def calculate_sensible_ahu_step(
 
     t_after_cooling = t_after_hr - actual_cooling_operating_w / rho_cp_q
 
-    # Step 8b: Heating coil targeting t_target so delivered temperature equals
-    # requested_t_sup after supply fan heat is added in step 9.  It sees the
+    # Heating coil targeting t_target so the delivered temperature equals
+    # requested_t_sup after supply-fan heat is added below.  It sees the
     # post-cooling temperature; with a single setpoint at most one coil is active.
     required_heating_operating_w = rho_cp_q * max(0.0, t_target - t_after_cooling)
     if config.heating_coil_max_power_w is None:
@@ -820,7 +794,7 @@ def calculate_sensible_ahu_step(
 
     t_after_coil = t_after_cooling + actual_heating_operating_w / rho_cp_q
 
-    # Step 9: Supply fan heat (after HR and coils, before zone delivery)
+    # Supply fan heat (after HR and coils, before zone delivery)
     t_actual_supply = t_after_coil + dt_sup_fan
 
     return AHUStepOutputs(
@@ -875,16 +849,14 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
     Required keys:
       ``sensible_heat_recovery_efficiency`` — float in [0, 1]
 
-    Supply temperature control — choose one mode:
-
-    Fixed (default; use when ``supply_temperature_mode`` is absent or "fixed"):
-      ``supply_temperature_setpoint_c``     — fixed setpoint [°C]
-
-    Outdoor-compensated (``supply_temperature_mode = "outdoor_compensated"``):
-      ``supply_temperature_points``         — list of [T_oda, T_sup] pairs, e.g.
-                                             [[-20, 19], [15, 17]] for ZEBlab
-      ``supply_temperature_minimum_c``      — optional clamp [°C]
-      ``supply_temperature_maximum_c``      — optional clamp [°C]
+    Supply temperature control — ``supply_temperature_mode`` selects one mode:
+      "fixed" (default):        ``supply_temperature_setpoint_c`` [°C]
+      "outdoor_compensated" /
+      "extract_compensated":    ``supply_temperature_points`` — list of
+                                [T_reference, T_supply] pairs, e.g.
+                                [[-20, 19], [15, 17]]
+      All modes accept optional ``supply_temperature_minimum_c`` and
+      ``supply_temperature_maximum_c`` clamps [°C].
 
     Optional keys and their defaults:
       ``heat_recovery_control``             — "modulating_bypass"
@@ -897,13 +869,16 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
       ``extract_fan_specific_power_w_per_m3_s`` — 0.0  (nominal SFP at design flow)
       ``supply_fan_heat_fraction_to_air``   — 0.90
       ``extract_fan_heat_fraction_to_air``  — 0.90
-      ``fan_performance_model``              — "en16798_5_1"
+      ``fan_performance_model``              — "en16798_5_1" (see FanPerformanceModel)
       ``supply_fan_design_pressure_pa``      — derived from nominal SFP and efficiency
       ``extract_fan_design_pressure_pa``     — derived from nominal SFP and efficiency
       ``supply_fan_nominal_efficiency``      — 0.72
       ``extract_fan_nominal_efficiency``     — 0.78
       ``*_fan_reference_flow_m3_h``          — required/design flow for the timestep
       ``*_fan_reference_efficiency``         — corresponding nominal efficiency
+
+    See docs/ventilation_ahu_audit.html for the full key reference and the
+    discussion of the defaulted fan product data.
     """
     heating_coil_max = d.get("heating_coil_max_power_w")
     if heating_coil_max is not None:
@@ -936,7 +911,7 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
         if not raw_pts:
             raise KeyError(
                 f"{ctrl_mode_str} control requires 'supply_temperature_points' "
-                "(list of [T_ref, T_sup] pairs, e.g. [[21, 19], [24, 17]] for ZEBlab)"
+                "(list of [T_ref, T_sup] pairs, e.g. [[21, 19], [24, 17]])"
             )
         points = tuple(
             CompensationPoint(

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -1,5 +1,10 @@
 """Sensible air-handling calculations based on EN 16798-5-1.
 
+The aim is to evaluate and demonstrate the calculation proposed by the standard.
+This work does not replace the standard; it should be used alongside the EPB standard.
+
+Acknowledgments: The work was developed from the standard and the spreadsheet created by EPB Center.
+
 The module is intentionally independent of the ISO 52016 zone solver. Supply
 temperature control is resolved before the EN 16798-5-1 thermodynamic
 calculation so that fixed, scheduled, outdoor-compensated, and
@@ -23,9 +28,11 @@ Standard air at sea level, approximately 20 °C:
 
 Fan heat placement
 ------------------
-Extract fan heat is added to extract air BEFORE the heat exchanger, increasing
-the temperature of air entering the HR core. Supply fan heat is added to
-supply air AFTER the heat exchanger and heating coil, just before delivery.
+The configured extract-fan heat fraction is added to extract air before the
+heat exchanger. Set ``extract_fan_heat_fraction_to_air=0`` for an extract fan
+located downstream of heat recovery or whose heat is otherwise not returned to
+the HR inlet. The configured supply-fan heat fraction is added after the heat
+exchanger and heating coil, just before delivery.
 """
 
 from __future__ import annotations
@@ -246,6 +253,21 @@ class FrostControlMode(str, Enum):
     EXHAUST_LIMIT = "exhaust_limit"
 
 
+class FanPerformanceModel(str, Enum):
+    """Fan power and temperature-rise calculation method.
+
+    EN16798_5_1 applies the single-zone no-control fan relations used by the
+    EN 16798-5-1 reference implementation: pressure varies with the square of
+    the flow ratio and fan efficiency follows the product-data square-root
+    correction.
+
+    CONSTANT_SFP retains the legacy relation P = q * SFP at every flow.
+    """
+
+    EN16798_5_1 = "en16798_5_1"
+    CONSTANT_SFP = "constant_sfp"
+
+
 @dataclass(frozen=True)
 class SensibleAHUConfig:
     """Configuration for the sensible EN 16798-5-1 AHU timestep model.
@@ -254,6 +276,20 @@ class SensibleAHUConfig:
     EXHAUST_LIMIT frost protection, modulating-bypass economizer, and a
     heating coil. Cooling coil support is not yet implemented;
     ``cooling_coil_enabled`` must be False.
+
+    Fan model:
+      ``supply_fan_specific_power_w_per_m3_s`` and
+      ``extract_fan_specific_power_w_per_m3_s`` are the **nominal** SFP values
+      at design flow. The default ``en16798_5_1`` model derives design pressure
+      from nominal SFP and nominal fan efficiency unless an explicit design
+      pressure is supplied. At part load it applies the EN 16798-5-1
+      single-zone no-control pressure relation and product-data efficiency
+      correction:
+
+      ``delta_p = delta_p_design * (q / q_design)**2``
+      ``eta = eta_ref * sqrt(q / q_ref)``
+
+      ``constant_sfp`` retains the legacy ``P = q * SFP`` relation.
     """
 
     sensible_heat_recovery_efficiency: float
@@ -267,6 +303,15 @@ class SensibleAHUConfig:
     supply_fan_heat_fraction_to_air: float
     extract_fan_heat_fraction_to_air: float
     frost_exhaust_limit_c: float = -5.0
+    fan_performance_model: FanPerformanceModel | str = FanPerformanceModel.EN16798_5_1
+    supply_fan_design_pressure_pa: float | None = None
+    extract_fan_design_pressure_pa: float | None = None
+    supply_fan_nominal_efficiency: float = 0.72
+    extract_fan_nominal_efficiency: float = 0.78
+    supply_fan_reference_flow_m3_h: float | None = None
+    extract_fan_reference_flow_m3_h: float | None = None
+    supply_fan_reference_efficiency: float | None = None
+    extract_fan_reference_efficiency: float | None = None
 
     def __post_init__(self) -> None:
         try:
@@ -287,6 +332,17 @@ class SensibleAHUConfig:
         except ValueError as exc:
             raise ValueError(
                 f"Unsupported frost_control: {self.frost_control!r}"
+            ) from exc
+
+        try:
+            object.__setattr__(
+                self,
+                "fan_performance_model",
+                FanPerformanceModel(self.fan_performance_model),
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported fan_performance_model: {self.fan_performance_model!r}"
             ) from exc
 
         eta = self.sensible_heat_recovery_efficiency
@@ -319,6 +375,26 @@ class SensibleAHUConfig:
                 raise ValueError(f"{name} must be finite and non-negative")
 
         for name, value in (
+            ("supply_fan_design_pressure_pa", self.supply_fan_design_pressure_pa),
+            ("extract_fan_design_pressure_pa", self.extract_fan_design_pressure_pa),
+            ("supply_fan_reference_flow_m3_h", self.supply_fan_reference_flow_m3_h),
+            ("extract_fan_reference_flow_m3_h", self.extract_fan_reference_flow_m3_h),
+        ):
+            if value is not None and (not math.isfinite(value) or value <= 0.0):
+                raise ValueError(f"{name} must be positive and finite when provided")
+
+        for name, value in (
+            ("supply_fan_nominal_efficiency", self.supply_fan_nominal_efficiency),
+            ("extract_fan_nominal_efficiency", self.extract_fan_nominal_efficiency),
+            ("supply_fan_reference_efficiency", self.supply_fan_reference_efficiency),
+            ("extract_fan_reference_efficiency", self.extract_fan_reference_efficiency),
+        ):
+            if value is not None and (
+                not math.isfinite(value) or value <= 0.0 or value > 1.0
+            ):
+                raise ValueError(f"{name} must be in (0, 1] when provided")
+
+        for name, value in (
             ("supply_fan_heat_fraction_to_air", self.supply_fan_heat_fraction_to_air),
             ("extract_fan_heat_fraction_to_air", self.extract_fan_heat_fraction_to_air),
         ):
@@ -336,7 +412,13 @@ class SensibleAHUConfig:
 
 @dataclass(frozen=True)
 class AHUStepInputs:
-    """Time-varying inputs for one AHU timestep."""
+    """Time-varying inputs for one AHU timestep.
+
+    ``operation_fraction`` is the fraction of the timestep for which the AHU
+    operates. ``flow_fraction`` is the continuous operating-flow ratio relative
+    to the required/design flow. Keeping these separate distinguishes ON/OFF
+    duty averaging from true fan-speed reduction.
+    """
 
     outdoor_temperature_c: float
     extract_temperature_c: float
@@ -345,6 +427,7 @@ class AHUStepInputs:
     operation_fraction: float
     timestep_hours: float
     scheduled_setpoint_c: float | None = None
+    flow_fraction: float = 1.0
 
     def __post_init__(self) -> None:
         for name, value in (
@@ -377,6 +460,12 @@ class AHUStepInputs:
             or not (0.0 <= self.operation_fraction <= 1.0)
         ):
             raise ValueError("operation_fraction must be finite and in [0, 1]")
+
+        if (
+            not math.isfinite(self.flow_fraction)
+            or not (0.0 <= self.flow_fraction <= 1.0)
+        ):
+            raise ValueError("flow_fraction must be finite and in [0, 1]")
 
         if not math.isfinite(self.timestep_hours) or self.timestep_hours <= 0.0:
             raise ValueError("timestep_hours must be positive and finite")
@@ -436,6 +525,74 @@ class AHUStepOutputs:
     frost_protection_required: bool
 
 
+def _fan_power_and_temperature_rise(
+    *,
+    model: FanPerformanceModel,
+    operating_flow_m3_h: float,
+    design_flow_m3_h: float,
+    operation_fraction: float,
+    nominal_specific_power_w_per_m3_s: float,
+    design_pressure_pa: float | None,
+    nominal_efficiency: float,
+    reference_flow_m3_h: float | None,
+    reference_efficiency: float | None,
+    heat_fraction_to_air: float,
+) -> tuple[float, float]:
+    """Return timestep-average fan electric power [W] and operating delta-T [K].
+
+    The EN 16798-5-1 mode follows the same pressure and fan-efficiency
+    relations as the recirc reference implementation. The temperature rise is
+    evaluated while the fan is operating; electric power is averaged over the
+    timestep using ``operation_fraction``.
+    """
+    if (
+        operating_flow_m3_h <= 0.0
+        or design_flow_m3_h <= 0.0
+        or operation_fraction <= 0.0
+    ):
+        return 0.0, 0.0
+
+    q_operating_m3_s = operating_flow_m3_h / 3600.0
+    if model is FanPerformanceModel.CONSTANT_SFP:
+        power_operating_w = (
+            q_operating_m3_s * nominal_specific_power_w_per_m3_s
+        )
+    else:
+        pressure_design_pa = (
+            design_pressure_pa
+            if design_pressure_pa is not None
+            else nominal_specific_power_w_per_m3_s * nominal_efficiency
+        )
+        if pressure_design_pa <= 0.0:
+            return 0.0, 0.0
+
+        q_ratio = operating_flow_m3_h / design_flow_m3_h
+        pressure_pa = pressure_design_pa * q_ratio ** 2
+
+        q_ref_m3_h = (
+            reference_flow_m3_h
+            if reference_flow_m3_h is not None
+            else design_flow_m3_h
+        )
+        eta_ref = (
+            reference_efficiency
+            if reference_efficiency is not None
+            else nominal_efficiency
+        )
+        efficiency = (
+            nominal_efficiency
+            * (eta_ref / nominal_efficiency)
+            * math.sqrt(operating_flow_m3_h / q_ref_m3_h)
+        )
+        power_operating_w = q_operating_m3_s * pressure_pa / efficiency
+
+    temperature_rise_k = (
+        power_operating_w * heat_fraction_to_air
+        / (_RHO_CP_J_M3_K * q_operating_m3_s)
+    )
+    return power_operating_w * operation_fraction, temperature_rise_k
+
+
 def calculate_sensible_ahu_step(
     config: SensibleAHUConfig,
     inputs: AHUStepInputs,
@@ -444,9 +601,9 @@ def calculate_sensible_ahu_step(
 
     Calculation sequence
     --------------------
-    1.  Scale flows by operation_fraction (scheduled CAV, balanced).  Return
-        zero-flow result immediately if AHU is off — avoids requiring a
-        scheduled setpoint when the AHU is not running.
+    1.  Scale operating flows by flow_fraction and timestep-average quantities
+        by operation_fraction. Return a zero-flow result immediately if the AHU
+        is off.
     2.  Resolve requested supply-temperature setpoint from config controller.
     3.  Compute fan electricity; add extract fan heat to extract before HR,
         accumulate supply fan heat for addition after HR and coil.
@@ -460,28 +617,32 @@ def calculate_sensible_ahu_step(
         outlet.  Compute total bypass_fraction combining frost and modulation.
     7.  Compute heat recovery power (net thermal gain to supply vs outdoor).
     8.  Compute required and actual heating-coil power; raise supply temperature.
-        Available coil power = heating_coil_max_power_w * operation_fraction
-        (ON/OFF scheduling: coil runs at rated power only during the ON fraction).
+        Coil capacity applies while operating; required and delivered powers are
+        then averaged over the timestep with operation_fraction.
     9.  Add supply fan heat to supply after coil.
     10. Return AHUStepOutputs with all quantities separated.
 
-    When operation_fraction is zero or required supply flow is zero, all flow
-    and energy outputs are zero and actual supply temperature equals outdoor.
+    When operation_fraction, flow_fraction, or required supply flow is zero,
+    all flow and energy outputs are zero and actual supply temperature equals
+    outdoor.
     """
     if not isinstance(config, SensibleAHUConfig):
         raise TypeError("config must be a SensibleAHUConfig")
     if not isinstance(inputs, AHUStepInputs):
         raise TypeError("inputs must be an AHUStepInputs")
 
-    # Step 2 first: Actual flows — needed to detect zero-flow before resolving setpoint
-    # so that scheduled control with no setpoint does not raise when the AHU is off.
+    # Step 1: distinguish operating flow from timestep-average flow. This keeps
+    # reduced fan speed separate from ON/OFF duty averaging.
     op = inputs.operation_fraction
-    actual_supply_m3_h = op * inputs.required_supply_flow_m3_h
-    actual_extract_m3_h = op * inputs.required_extract_flow_m3_h
-    q_sup = actual_supply_m3_h / 3600.0  # m³/s
-    q_eta = actual_extract_m3_h / 3600.0  # m³/s
+    flow_fraction = inputs.flow_fraction
+    operating_supply_m3_h = flow_fraction * inputs.required_supply_flow_m3_h
+    operating_extract_m3_h = flow_fraction * inputs.required_extract_flow_m3_h
+    actual_supply_m3_h = op * operating_supply_m3_h
+    actual_extract_m3_h = op * operating_extract_m3_h
+    q_sup = operating_supply_m3_h / 3600.0  # m³/s while operating
+    q_eta = operating_extract_m3_h / 3600.0  # m³/s while operating
 
-    if q_sup <= 0.0:
+    if op <= 0.0 or q_sup <= 0.0:
         return AHUStepOutputs(
             requested_supply_temperature_c=None,
             actual_supply_temperature_c=inputs.outdoor_temperature_c,
@@ -506,19 +667,37 @@ def calculate_sensible_ahu_step(
 
     rho_cp_q = _RHO_CP_J_M3_K * q_sup  # W/K for supply stream
 
-    # Step 3: Fan electricity and temperature rises
-    p_sup_fan = q_sup * config.supply_fan_specific_power_w_per_m3_s
-    p_eta_fan = q_eta * config.extract_fan_specific_power_w_per_m3_s
-    fan_electric_power_w = p_sup_fan + p_eta_fan
-
-    # Extract fan heat warms extract entering the HR
-    dt_eta_fan = (
-        p_eta_fan * config.extract_fan_heat_fraction_to_air / (_RHO_CP_J_M3_K * q_eta)
-        if q_eta > 0.0
-        else 0.0
+    # Step 3: fan electricity and temperature rises. Power outputs are
+    # timestep averages; temperature rises describe the operating airstream.
+    p_sup_fan, dt_sup_fan = _fan_power_and_temperature_rise(
+        model=config.fan_performance_model,
+        operating_flow_m3_h=operating_supply_m3_h,
+        design_flow_m3_h=inputs.required_supply_flow_m3_h,
+        operation_fraction=op,
+        nominal_specific_power_w_per_m3_s=(
+            config.supply_fan_specific_power_w_per_m3_s
+        ),
+        design_pressure_pa=config.supply_fan_design_pressure_pa,
+        nominal_efficiency=config.supply_fan_nominal_efficiency,
+        reference_flow_m3_h=config.supply_fan_reference_flow_m3_h,
+        reference_efficiency=config.supply_fan_reference_efficiency,
+        heat_fraction_to_air=config.supply_fan_heat_fraction_to_air,
     )
-    # Supply fan heat is applied after coil (accumulated now, used at step 9)
-    dt_sup_fan = p_sup_fan * config.supply_fan_heat_fraction_to_air / rho_cp_q
+    p_eta_fan, dt_eta_fan = _fan_power_and_temperature_rise(
+        model=config.fan_performance_model,
+        operating_flow_m3_h=operating_extract_m3_h,
+        design_flow_m3_h=inputs.required_extract_flow_m3_h,
+        operation_fraction=op,
+        nominal_specific_power_w_per_m3_s=(
+            config.extract_fan_specific_power_w_per_m3_s
+        ),
+        design_pressure_pa=config.extract_fan_design_pressure_pa,
+        nominal_efficiency=config.extract_fan_nominal_efficiency,
+        reference_flow_m3_h=config.extract_fan_reference_flow_m3_h,
+        reference_efficiency=config.extract_fan_reference_efficiency,
+        heat_fraction_to_air=config.extract_fan_heat_fraction_to_air,
+    )
+    fan_electric_power_w = p_sup_fan + p_eta_fan
 
     t_outdoor = inputs.outdoor_temperature_c
     t_ext_at_hr = inputs.extract_temperature_c + dt_eta_fan
@@ -579,30 +758,25 @@ def calculate_sensible_ahu_step(
         bypass_fraction = 0.0
 
     # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
-    hr_power_w = rho_cp_q * (t_after_hr - t_outdoor)
+    hr_power_operating_w = rho_cp_q * (t_after_hr - t_outdoor)
 
     # Unmet cooling: power that would be needed to reach t_target but cannot be
     # delivered because no cooling coil is present.  Positive when bypass has been
     # driven to its limit and the supply is still above the setpoint.
-    required_cooling_coil_w = rho_cp_q * max(0.0, t_after_hr - t_target)
+    required_cooling_operating_w = rho_cp_q * max(0.0, t_after_hr - t_target)
 
     # Step 8: Heating coil targeting t_target so delivered temperature equals
     # requested_t_sup after supply fan heat is added in step 9.
-    # For ON/OFF scheduling (operation_fraction < 1), the time-averaged available
-    # coil power is coil_max * op: the coil runs at rated power only during the ON
-    # fraction, so the timestep-average is proportionally reduced.
-    required_heating_w = rho_cp_q * max(0.0, t_target - t_after_hr)
-    available_heating_w = (
-        config.heating_coil_max_power_w * op
-        if config.heating_coil_max_power_w is not None
-        else None
-    )
-    if available_heating_w is None:
-        actual_heating_w = required_heating_w
+    required_heating_operating_w = rho_cp_q * max(0.0, t_target - t_after_hr)
+    if config.heating_coil_max_power_w is None:
+        actual_heating_operating_w = required_heating_operating_w
     else:
-        actual_heating_w = min(required_heating_w, available_heating_w)
+        actual_heating_operating_w = min(
+            required_heating_operating_w,
+            config.heating_coil_max_power_w,
+        )
 
-    t_after_coil = t_after_hr + actual_heating_w / rho_cp_q
+    t_after_coil = t_after_hr + actual_heating_operating_w / rho_cp_q
 
     # Step 9: Supply fan heat (after HR and coil, before zone delivery)
     t_actual_supply = t_after_coil + dt_sup_fan
@@ -612,11 +786,11 @@ def calculate_sensible_ahu_step(
         actual_supply_temperature_c=t_actual_supply,
         actual_supply_flow_m3_h=actual_supply_m3_h,
         actual_extract_flow_m3_h=actual_extract_m3_h,
-        required_heating_coil_power_w=required_heating_w,
-        actual_heating_coil_power_w=actual_heating_w,
-        required_cooling_coil_power_w=required_cooling_coil_w,
+        required_heating_coil_power_w=required_heating_operating_w * op,
+        actual_heating_coil_power_w=actual_heating_operating_w * op,
+        required_cooling_coil_power_w=required_cooling_operating_w * op,
         fan_electric_power_w=fan_electric_power_w,
-        heat_recovery_power_w=hr_power_w,
+        heat_recovery_power_w=hr_power_operating_w * op,
         bypass_fraction=bypass_fraction,
         frost_protection_required=frost_protection_req,
     )
@@ -653,10 +827,17 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
       ``frost_exhaust_limit_c``             — -5.0 [°C]
       ``heating_coil_max_power_w``          — None (unlimited)
       ``cooling_coil_enabled``              — False
-      ``supply_fan_specific_power_w_per_m3_s`` — 0.0
-      ``extract_fan_specific_power_w_per_m3_s`` — 0.0
+      ``supply_fan_specific_power_w_per_m3_s`` — 0.0  (nominal SFP at design flow)
+      ``extract_fan_specific_power_w_per_m3_s`` — 0.0  (nominal SFP at design flow)
       ``supply_fan_heat_fraction_to_air``   — 1.0
       ``extract_fan_heat_fraction_to_air``  — 1.0
+      ``fan_performance_model``              — "en16798_5_1"
+      ``supply_fan_design_pressure_pa``      — derived from nominal SFP and efficiency
+      ``extract_fan_design_pressure_pa``     — derived from nominal SFP and efficiency
+      ``supply_fan_nominal_efficiency``      — 0.72
+      ``extract_fan_nominal_efficiency``     — 0.78
+      ``*_fan_reference_flow_m3_h``          — required/design flow for the timestep
+      ``*_fan_reference_efficiency``         — corresponding nominal efficiency
     """
     heating_coil_max = d.get("heating_coil_max_power_w")
     if heating_coil_max is not None:
@@ -675,12 +856,17 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
             minimum_c=_opt_float(d.get("supply_temperature_minimum_c")),
             maximum_c=_opt_float(d.get("supply_temperature_maximum_c")),
         )
-    elif ctrl_mode_str == "outdoor_compensated":
+    elif ctrl_mode_str in ("outdoor_compensated", "extract_compensated"):
+        mode_enum = (
+            SupplyTemperatureControlMode.OUTDOOR_COMPENSATED
+            if ctrl_mode_str == "outdoor_compensated"
+            else SupplyTemperatureControlMode.EXTRACT_COMPENSATED
+        )
         raw_pts = d.get("supply_temperature_points")
         if not raw_pts:
             raise KeyError(
-                "outdoor_compensated control requires 'supply_temperature_points' "
-                "(list of [T_oda, T_sup] pairs)"
+                f"{ctrl_mode_str} control requires 'supply_temperature_points' "
+                "(list of [T_ref, T_sup] pairs, e.g. [[21, 19], [24, 17]] for ZEBlab)"
             )
         points = tuple(
             CompensationPoint(
@@ -690,7 +876,7 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
             for p in raw_pts
         )
         supply_ctrl = SupplyTemperatureControl(
-            mode=SupplyTemperatureControlMode.OUTDOOR_COMPENSATED,
+            mode=mode_enum,
             points=points,
             minimum_c=_opt_float(d.get("supply_temperature_minimum_c")),
             maximum_c=_opt_float(d.get("supply_temperature_maximum_c")),
@@ -698,7 +884,7 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
     else:
         raise ValueError(
             f"Unsupported supply_temperature_mode: {ctrl_mode_str!r}. "
-            "Supported: 'fixed', 'outdoor_compensated'."
+            "Supported: 'fixed', 'outdoor_compensated', 'extract_compensated'."
         )
 
     return SensibleAHUConfig(
@@ -720,6 +906,33 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
         ),
         extract_fan_heat_fraction_to_air=float(
             d.get("extract_fan_heat_fraction_to_air", 1.0)
+        ),
+        fan_performance_model=str(
+            d.get("fan_performance_model", "en16798_5_1")
+        ),
+        supply_fan_design_pressure_pa=_opt_float(
+            d.get("supply_fan_design_pressure_pa")
+        ),
+        extract_fan_design_pressure_pa=_opt_float(
+            d.get("extract_fan_design_pressure_pa")
+        ),
+        supply_fan_nominal_efficiency=float(
+            d.get("supply_fan_nominal_efficiency", 0.72)
+        ),
+        extract_fan_nominal_efficiency=float(
+            d.get("extract_fan_nominal_efficiency", 0.78)
+        ),
+        supply_fan_reference_flow_m3_h=_opt_float(
+            d.get("supply_fan_reference_flow_m3_h")
+        ),
+        extract_fan_reference_flow_m3_h=_opt_float(
+            d.get("extract_fan_reference_flow_m3_h")
+        ),
+        supply_fan_reference_efficiency=_opt_float(
+            d.get("supply_fan_reference_efficiency")
+        ),
+        extract_fan_reference_efficiency=_opt_float(
+            d.get("extract_fan_reference_efficiency")
         ),
     )
 

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -228,13 +228,17 @@ class FrostControlMode(str, Enum):
     """Available frost-protection strategies.
 
     NONE         — no frost protection; HR efficiency is not reduced.
-    EXHAUST_LIMIT — indirect exhaust-temperature-limit control (EN 16798-5-1
-                   B108=2 "INDIRECT" mode): the effective HR efficiency is
-                   reduced continuously so the exhaust leaving the HR core
-                   stays at or above ``frost_exhaust_limit_c``.  B108 selects
-                   the control method (B108=1 = DIRECT, B108=2 = INDIRECT);
-                   the defrost mechanism (bypass, preheat, recirculation) is a
-                   separate configuration dimension not represented here.
+    EXHAUST_LIMIT — directly reduces the effective HR efficiency so the
+                   exhaust leaving the HR core stays at or above
+                   ``frost_exhaust_limit_c``.  The continuous exhaust-
+                   temperature-limit formulation is mechanistically
+                   similar to EN 16798-5-1 B108=1 DIRECT (direct
+                   effectiveness control): both reduce ηhr when frost
+                   risk is present.  It differs from B108=2 INDIRECT,
+                   which adjusts the ODA preheating temperature (JODA;fp)
+                   and leaves ηhr unchanged.  B46 (defrost mechanism:
+                   bypass, preheat, recirculation) is a separate
+                   configuration dimension not modelled here.
     """
 
     NONE = "none"
@@ -519,7 +523,9 @@ def calculate_sensible_ahu_step(
     eta_nom = config.sensible_heat_recovery_efficiency
     dT = t_ext_at_hr - t_outdoor  # K; positive in heating mode
 
-    # Step 4: EXHAUST_LIMIT frost protection (EN 16798-5-1 B108=2 INDIRECT).
+    # Step 4: EXHAUST_LIMIT frost protection — directly reduces effective HR
+    # efficiency to keep T_EHA >= frost_exhaust_limit_c (analogous to
+    # EN 16798-5-1 B108=1 DIRECT effectiveness control).
     # The exhaust leaving the HR (EHA) must stay >= frost_exhaust_limit_c.
     # For balanced flow: T_EHA = T_extract_at_hr - eta * dT
     # If T_EHA < limit, reduce eta_eff so T_EHA exactly equals the limit.

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -19,7 +19,7 @@ that produces theta_SUP_req_zV for the AHU calculation.
 Physical constants
 ------------------
 Standard air at sea level, approximately 20 °C:
-  rho = 1.204 kg/m³,  cp = 1005 J/(kg·K)  →  rho*cp = 1209 J/(m³·K)
+  rho = 1.204 kg/m³,  cp = 1005 J/(kg·K)  →  rho*cp = 1210.02 J/(m³·K)
 
 Fan heat placement
 ------------------
@@ -43,7 +43,7 @@ from .ventilation import VentilationStream
 
 _RHO_AIR_KG_M3: float = 1.204
 _CP_AIR_J_KG_K: float = 1005.0
-_RHO_CP_J_M3_K: float = _RHO_AIR_KG_M3 * _CP_AIR_J_KG_K  # 1209.0 J/(m³·K)
+_RHO_CP_J_M3_K: float = _RHO_AIR_KG_M3 * _CP_AIR_J_KG_K  # 1210.02 J/(m³·K)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -19,7 +19,7 @@ that produces theta_SUP_req_zV for the AHU calculation.
 Physical constants
 ------------------
 Standard air at sea level, approximately 20 °C:
-  rho = 1.204 kg/m³,  cp = 1005 J/(kg·K)  →  rho*cp = 1210.02 J/(m³·K)
+  rho = 1.204 kg/m³,  cp = 1006 J/(kg·K)  →  rho*cp = 1211.224 J/(m³·K)
 
 Fan heat placement
 ------------------
@@ -42,8 +42,8 @@ from .ventilation import VentilationStream
 # ---------------------------------------------------------------------------
 
 _RHO_AIR_KG_M3: float = 1.204
-_CP_AIR_J_KG_K: float = 1005.0
-_RHO_CP_J_M3_K: float = _RHO_AIR_KG_M3 * _CP_AIR_J_KG_K  # 1210.02 J/(m³·K)
+_CP_AIR_J_KG_K: float = 1006.0
+_RHO_CP_J_M3_K: float = _RHO_AIR_KG_M3 * _CP_AIR_J_KG_K  # 1211.224 J/(m³·K)
 
 
 # ---------------------------------------------------------------------------
@@ -638,5 +638,5 @@ def ahu_outputs_to_ventilation_stream(
         name=name,
         heat_transfer_coefficient_w_k=h_w_k,
         source_temperature_c=outputs.actual_supply_temperature_c,
-        category="mechanical_supply",
+        category="supply",
     )

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -223,20 +223,29 @@ class HeatRecoveryControl(str, Enum):
 
 
 class FrostControlMode(str, Enum):
-    """Available frost-protection strategies."""
+    """Available frost-protection strategies.
+
+    NONE         — no frost protection; HR efficiency is not reduced.
+    EXHAUST_LIMIT — indirect exhaust-temperature-limit control (EN 16798-5-1
+                   B108=2 "DIRECT" mode): the effective HR efficiency is
+                   reduced continuously so the exhaust leaving the HR core
+                   stays at or above ``frost_exhaust_limit_c``.  This is
+                   equivalent to an effective partial bypass but is physically
+                   distinct from a full-bypass damper (B108=1).
+    """
 
     NONE = "none"
-    BYPASS = "bypass"
+    EXHAUST_LIMIT = "exhaust_limit"
 
 
 @dataclass(frozen=True)
 class SensibleAHUConfig:
     """Configuration for the sensible EN 16798-5-1 AHU timestep model.
 
-    Covers balanced scheduled CAV with sensible heat recovery, bypass frost
-    control, modulating-bypass economizer, and a heating coil. Cooling coil
-    support is reserved for future implementation; setting cooling_coil_enabled
-    to True is accepted but has no effect in this version.
+    Covers balanced scheduled CAV with sensible heat recovery,
+    EXHAUST_LIMIT frost protection, modulating-bypass economizer, and a
+    heating coil. Cooling coil support is not yet implemented;
+    ``cooling_coil_enabled`` must be False.
     """
 
     sensible_heat_recovery_efficiency: float
@@ -311,6 +320,11 @@ class SensibleAHUConfig:
         if not math.isfinite(self.frost_exhaust_limit_c):
             raise ValueError("frost_exhaust_limit_c must be finite")
 
+        if self.cooling_coil_enabled:
+            raise NotImplementedError(
+                "cooling_coil_enabled=True is not yet implemented; set to False"
+            )
+
 
 @dataclass(frozen=True)
 class AHUStepInputs:
@@ -339,6 +353,17 @@ class AHUStepInputs:
             if not math.isfinite(value) or value < 0.0:
                 raise ValueError(f"{name} must be finite and non-negative")
 
+        q_sup = self.required_supply_flow_m3_h
+        q_ext = self.required_extract_flow_m3_h
+        if q_sup != q_ext:
+            larger = max(q_sup, q_ext)
+            if larger == 0.0 or abs(q_sup - q_ext) / larger > 1e-6:
+                raise ValueError(
+                    "required_supply_flow_m3_h and required_extract_flow_m3_h must be "
+                    "equal: unequal supply and extract flow is outside the balanced-flow "
+                    "scope"
+                )
+
         if (
             not math.isfinite(self.operation_fraction)
             or not (0.0 <= self.operation_fraction <= 1.0)
@@ -364,7 +389,12 @@ class AHUStepOutputs:
 
     requested_supply_temperature_c: setpoint from the supply-temperature controller.
     actual_supply_temperature_c:    delivered supply temperature including fan heat.
-    heat_recovery_power_w:          net sensible heat transferred to supply (positive).
+    heat_recovery_power_w:          net sensible heat transferred to supply air by the HR
+                                    unit, relative to raw outdoor air: rho*cp*q*(T_hr−T_oda).
+                                    Equals EN 16798-5-1 formula-77 Q_hr for balanced flow
+                                    without recirculation or ODA preheating.  Positive in
+                                    heating mode; negative in economizer mode (ALWAYS_ON HR
+                                    or partial MODULATING_BYPASS cooling).
     required_heating_coil_power_w:  coil power needed to reach setpoint.
     actual_heating_coil_power_w:    coil power actually delivered (≤ required).
     fan_electric_power_w:           total fan electrical power (separate from thermal).
@@ -392,17 +422,24 @@ def calculate_sensible_ahu_step(
 
     Calculation sequence
     --------------------
-    1.  Resolve requested supply-temperature setpoint from config controller.
-    2.  Scale flows by operation_fraction (scheduled CAV, balanced).
+    1.  Scale flows by operation_fraction (scheduled CAV, balanced).  Return
+        zero-flow result immediately if AHU is off — avoids requiring a
+        scheduled setpoint when the AHU is not running.
+    2.  Resolve requested supply-temperature setpoint from config controller.
     3.  Compute fan electricity; add extract fan heat to extract before HR,
         accumulate supply fan heat for addition after HR and coil.
-    4.  Apply bypass frost protection: reduce effective HR efficiency so the
-        exhaust leaving the HR stays at or above frost_exhaust_limit_c.
+    4.  Apply EXHAUST_LIMIT frost protection: reduce effective HR efficiency
+        so the exhaust leaving the HR stays at or above frost_exhaust_limit_c.
     5.  Compute HR outlet temperature from outdoor and frost-limited efficiency.
-    6.  Apply modulating bypass (if configured) to track supply setpoint without
-        overshooting in either heating or economizer direction.
+    6.  Compute fan-adjusted internal coil target: subtract downstream supply fan
+        heat from requested setpoint so that delivered temperature equals requested
+        after the fan addition.  Apply modulating bypass (clamped to [0, 1]) to
+        reach internal target; full bypass yields outdoor air, no bypass yields HR
+        outlet.  Compute total bypass_fraction combining frost and modulation.
     7.  Compute heat recovery power (net thermal gain to supply vs outdoor).
     8.  Compute required and actual heating-coil power; raise supply temperature.
+        Available coil power = heating_coil_max_power_w * operation_fraction
+        (ON/OFF scheduling: coil runs at rated power only during the ON fraction).
     9.  Add supply fan heat to supply after coil.
     10. Return AHUStepOutputs with all quantities separated.
 
@@ -414,15 +451,8 @@ def calculate_sensible_ahu_step(
     if not isinstance(inputs, AHUStepInputs):
         raise TypeError("inputs must be an AHUStepInputs")
 
-    # Step 1: Resolve requested setpoint
-    requested_t_sup = resolve_supply_temperature_setpoint(
-        config.supply_temperature_control,
-        inputs.outdoor_temperature_c,
-        inputs.extract_temperature_c,
-        inputs.scheduled_setpoint_c,
-    )
-
-    # Step 2: Actual flows (balanced scheduled CAV)
+    # Step 2 first: Actual flows — needed to detect zero-flow before resolving setpoint
+    # so that scheduled control with no setpoint does not raise when the AHU is off.
     op = inputs.operation_fraction
     actual_supply_m3_h = op * inputs.required_supply_flow_m3_h
     actual_extract_m3_h = op * inputs.required_extract_flow_m3_h
@@ -431,7 +461,7 @@ def calculate_sensible_ahu_step(
 
     if q_sup <= 0.0:
         return AHUStepOutputs(
-            requested_supply_temperature_c=requested_t_sup,
+            requested_supply_temperature_c=inputs.outdoor_temperature_c,
             actual_supply_temperature_c=inputs.outdoor_temperature_c,
             actual_supply_flow_m3_h=0.0,
             actual_extract_flow_m3_h=0.0,
@@ -442,6 +472,14 @@ def calculate_sensible_ahu_step(
             bypass_fraction=0.0,
             frost_control_active=False,
         )
+
+    # Step 1: Resolve requested setpoint (only reached when AHU is actually running)
+    requested_t_sup = resolve_supply_temperature_setpoint(
+        config.supply_temperature_control,
+        inputs.outdoor_temperature_c,
+        inputs.extract_temperature_c,
+        inputs.scheduled_setpoint_c,
+    )
 
     rho_cp_q = _RHO_CP_J_M3_K * q_sup  # W/K for supply stream
 
@@ -471,7 +509,7 @@ def calculate_sensible_ahu_step(
     frost_active = False
     eta_eff = eta_nom
     if (
-        config.frost_control is FrostControlMode.BYPASS
+        config.frost_control is FrostControlMode.EXHAUST_LIMIT
         and eta_nom > 0.0
         and abs(dT) > 1e-9
     ):
@@ -484,32 +522,58 @@ def calculate_sensible_ahu_step(
     # Step 5: HR outlet temperature (before modulation)
     t_after_hr = t_outdoor + eta_eff * dT
 
-    # Step 6: Modulating bypass to track requested setpoint
-    # Bypass mixes raw outdoor air with HR output.  The formula
-    #   bp = (T_hr - T_set) / (T_hr - T_oda)
-    # applies in both heating mode (HR overshoots setpoint) and economizer
-    # mode (HR overcools below setpoint when T_oda > T_extract).
-    # Bypass is only triggered when T_set lies strictly between T_oda and T_hr.
-    bypass_fraction = 0.0
+    # Step 6: Modulating bypass and total bypass_fraction.
+    # Internal target: subtract downstream supply fan heat so delivered temperature
+    # equals requested_t_sup after the fan addition in step 9.
+    t_target = requested_t_sup - dt_sup_fan
+
+    # Bypass formula: bp = (T_hr - T_target) / (T_hr - T_outdoor), clamped to [0, 1].
+    # bp = 1 → full bypass, delivers T_outdoor.  bp = 0 → no bypass, delivers T_hr.
+    # Clamping handles setpoints outside the achievable mixing range: when the
+    # setpoint is below T_outdoor (heating mode, no cooling), full bypass delivers
+    # the closest attainable temperature; when the setpoint is above T_outdoor
+    # (economizer mode overshoot), full bypass delivers T_outdoor.
+    #
+    # Reference deviation: EN 16798-5-1 Table B.2 modes B91=2 (FIXED) and B91=3
+    # (ODA_COMP) fully bypass the HR in economizer mode (T_outdoor > T_extract),
+    # delivering T_outdoor regardless of the setpoint. Our implementation modulates
+    # to the setpoint using partial HR, which is physically more accurate. The
+    # reference LOAD_COMP mode (B91=4, closest to EXTRACT_COMPENSATED) does allow
+    # partial HR in economizer mode and aligns with our behaviour.
     if config.heat_recovery_control is HeatRecoveryControl.MODULATING_BYPASS:
         dT_hr_oda = t_after_hr - t_outdoor  # = eta_eff * dT
         if abs(dT_hr_oda) > 1e-9:
-            t_low = min(t_outdoor, t_after_hr)
-            t_high = max(t_outdoor, t_after_hr)
-            if t_low < requested_t_sup < t_high:
-                bypass_fraction = (t_after_hr - requested_t_sup) / dT_hr_oda
-                bypass_fraction = max(0.0, min(1.0, bypass_fraction))
-                t_after_hr = requested_t_sup  # setpoint achieved by mixing
+            bp = (t_after_hr - t_target) / dT_hr_oda
+            bp = max(0.0, min(1.0, bp))
+            t_after_hr = t_outdoor * bp + t_after_hr * (1.0 - bp)
+
+    # Total effective bypass fraction: fraction of supply air bypassing the HR core
+    # due to both frost protection (step 4) and setpoint modulation above.
+    if eta_nom > 0.0 and abs(dT) > 1e-9:
+        bypass_fraction = max(
+            0.0, min(1.0, 1.0 - (t_after_hr - t_outdoor) / (eta_nom * dT))
+        )
+    else:
+        bypass_fraction = 0.0
 
     # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
     hr_power_w = rho_cp_q * (t_after_hr - t_outdoor)
 
-    # Step 8: Heating coil
-    required_heating_w = rho_cp_q * max(0.0, requested_t_sup - t_after_hr)
-    if config.heating_coil_max_power_w is None:
+    # Step 8: Heating coil targeting t_target so delivered temperature equals
+    # requested_t_sup after supply fan heat is added in step 9.
+    # For ON/OFF scheduling (operation_fraction < 1), the time-averaged available
+    # coil power is coil_max * op: the coil runs at rated power only during the ON
+    # fraction, so the timestep-average is proportionally reduced.
+    required_heating_w = rho_cp_q * max(0.0, t_target - t_after_hr)
+    available_heating_w = (
+        config.heating_coil_max_power_w * op
+        if config.heating_coil_max_power_w is not None
+        else None
+    )
+    if available_heating_w is None:
         actual_heating_w = required_heating_w
     else:
-        actual_heating_w = min(required_heating_w, config.heating_coil_max_power_w)
+        actual_heating_w = min(required_heating_w, available_heating_w)
 
     t_after_coil = t_after_hr + actual_heating_w / rho_cp_q
 

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -626,12 +626,26 @@ def calculate_sensible_ahu_step(
 # ISO 52016-1 zone adapter
 # ---------------------------------------------------------------------------
 
+def _opt_float(v) -> "float | None":
+    return None if v is None else float(v)
+
+
 def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
     """Build a SensibleAHUConfig from a ventilation component dict.
 
     Required keys:
       ``sensible_heat_recovery_efficiency`` — float in [0, 1]
-      ``supply_temperature_setpoint_c``     — fixed supply setpoint [°C]
+
+    Supply temperature control — choose one mode:
+
+    Fixed (default; use when ``supply_temperature_mode`` is absent or "fixed"):
+      ``supply_temperature_setpoint_c``     — fixed setpoint [°C]
+
+    Outdoor-compensated (``supply_temperature_mode = "outdoor_compensated"``):
+      ``supply_temperature_points``         — list of [T_oda, T_sup] pairs, e.g.
+                                             [[-20, 19], [15, 17]] for ZEBlab
+      ``supply_temperature_minimum_c``      — optional clamp [°C]
+      ``supply_temperature_maximum_c``      — optional clamp [°C]
 
     Optional keys and their defaults:
       ``heat_recovery_control``             — "modulating_bypass"
@@ -644,20 +658,52 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
       ``supply_fan_heat_fraction_to_air``   — 1.0
       ``extract_fan_heat_fraction_to_air``  — 1.0
     """
-    raw_setpoint = d.get("supply_temperature_setpoint_c")
-    if raw_setpoint is None:
-        raise KeyError(
-            "mechanical_supply component requires 'supply_temperature_setpoint_c'"
-        )
     heating_coil_max = d.get("heating_coil_max_power_w")
     if heating_coil_max is not None:
         heating_coil_max = float(heating_coil_max)
-    return SensibleAHUConfig(
-        sensible_heat_recovery_efficiency=float(d["sensible_heat_recovery_efficiency"]),
-        supply_temperature_control=SupplyTemperatureControl(
+
+    ctrl_mode_str = str(d.get("supply_temperature_mode", "fixed")).strip().lower()
+    if ctrl_mode_str in ("fixed", ""):
+        raw_setpoint = d.get("supply_temperature_setpoint_c")
+        if raw_setpoint is None:
+            raise KeyError(
+                "fixed supply control requires 'supply_temperature_setpoint_c'"
+            )
+        supply_ctrl = SupplyTemperatureControl(
             mode=SupplyTemperatureControlMode.FIXED,
             setpoint_c=float(raw_setpoint),
-        ),
+            minimum_c=_opt_float(d.get("supply_temperature_minimum_c")),
+            maximum_c=_opt_float(d.get("supply_temperature_maximum_c")),
+        )
+    elif ctrl_mode_str == "outdoor_compensated":
+        raw_pts = d.get("supply_temperature_points")
+        if not raw_pts:
+            raise KeyError(
+                "outdoor_compensated control requires 'supply_temperature_points' "
+                "(list of [T_oda, T_sup] pairs)"
+            )
+        points = tuple(
+            CompensationPoint(
+                reference_temperature_c=float(p[0]),
+                supply_temperature_c=float(p[1]),
+            )
+            for p in raw_pts
+        )
+        supply_ctrl = SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.OUTDOOR_COMPENSATED,
+            points=points,
+            minimum_c=_opt_float(d.get("supply_temperature_minimum_c")),
+            maximum_c=_opt_float(d.get("supply_temperature_maximum_c")),
+        )
+    else:
+        raise ValueError(
+            f"Unsupported supply_temperature_mode: {ctrl_mode_str!r}. "
+            "Supported: 'fixed', 'outdoor_compensated'."
+        )
+
+    return SensibleAHUConfig(
+        sensible_heat_recovery_efficiency=float(d["sensible_heat_recovery_efficiency"]),
+        supply_temperature_control=supply_ctrl,
         heat_recovery_control=str(d.get("heat_recovery_control", "modulating_bypass")),
         frost_control=str(d.get("frost_control", "exhaust_limit")),
         frost_exhaust_limit_c=float(d.get("frost_exhaust_limit_c", -5.0)),

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass
 from enum import Enum
 import math
 
+from .ventilation import VentilationStream
+
 
 # ---------------------------------------------------------------------------
 # Physical constants
@@ -609,4 +611,32 @@ def calculate_sensible_ahu_step(
         heat_recovery_power_w=hr_power_w,
         bypass_fraction=bypass_fraction,
         frost_protection_required=frost_protection_req,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ISO 52016-1 zone adapter
+# ---------------------------------------------------------------------------
+
+def ahu_outputs_to_ventilation_stream(
+    outputs: AHUStepOutputs,
+    name: str = "mechanical_supply",
+) -> VentilationStream:
+    """Convert AHU step outputs into a VentilationStream for ISO 52016-1 §6.5.10.
+
+    The stream conductance and source temperature couple the AHU into the
+    zone affine ventilation boundary:
+
+        H_k = rho_air * cp_air * actual_supply_flow [W/K]
+        T_source,k = actual_supply_temperature [°C]
+
+    When the AHU is off (zero flow), H_k = 0 so the stream contributes
+    nothing to the zone balance regardless of source temperature.
+    """
+    h_w_k = _RHO_CP_J_M3_K * outputs.actual_supply_flow_m3_h / 3600.0
+    return VentilationStream(
+        name=name,
+        heat_transfer_coefficient_w_k=h_w_k,
+        source_temperature_c=outputs.actual_supply_temperature_c,
+        category="mechanical_supply",
     )

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -1,0 +1,181 @@
+"""Sensible air-handling calculations based on EN 16798-5-1.
+
+The module is intentionally independent of the ISO 52016 zone solver. Supply
+temperature control is resolved before the EN 16798-5-1 thermodynamic
+calculation so that fixed, scheduled, outdoor-compensated, and
+extract-compensated supervisory controls share one explicit and testable
+interface.
+
+Only the supply-temperature controller is implemented in this first slice.
+Heat recovery, frost protection, coils, fans, and conversion to an ISO 52016
+ventilation stream are added separately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import math
+
+
+class SupplyTemperatureControlMode(str, Enum):
+    """Available supply-air temperature setpoint strategies."""
+
+    FIXED = "fixed"
+    SCHEDULED = "scheduled"
+    OUTDOOR_COMPENSATED = "outdoor_compensated"
+    EXTRACT_COMPENSATED = "extract_compensated"
+
+
+@dataclass(frozen=True)
+class CompensationPoint:
+    """One point on a supply-temperature compensation curve."""
+
+    reference_temperature_c: float
+    supply_temperature_c: float
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.reference_temperature_c):
+            raise ValueError("reference_temperature_c must be finite")
+        if not math.isfinite(self.supply_temperature_c):
+            raise ValueError("supply_temperature_c must be finite")
+
+
+@dataclass(frozen=True)
+class SupplyTemperatureControl:
+    """Configuration for a requested AHU supply-temperature setpoint.
+
+    Compensation curves are sorted by reference temperature and use
+    piecewise-linear interpolation. Values outside the curve are clamped to
+    the nearest endpoint.
+    """
+
+    mode: SupplyTemperatureControlMode
+    setpoint_c: float | None = None
+    points: tuple[CompensationPoint, ...] = ()
+    minimum_c: float | None = None
+    maximum_c: float | None = None
+    extrapolation: str = "clamp"
+
+    def __post_init__(self) -> None:
+        try:
+            mode = SupplyTemperatureControlMode(self.mode)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported supply-temperature control mode: {self.mode!r}"
+            ) from exc
+        object.__setattr__(self, "mode", mode)
+
+        points = tuple(self.points)
+        if any(not isinstance(point, CompensationPoint) for point in points):
+            raise TypeError("points must contain CompensationPoint instances")
+        points = tuple(sorted(points, key=lambda point: point.reference_temperature_c))
+        object.__setattr__(self, "points", points)
+
+        references = [point.reference_temperature_c for point in points]
+        if len(references) != len(set(references)):
+            raise ValueError("Compensation reference temperatures must be unique")
+
+        for name, value in (
+            ("setpoint_c", self.setpoint_c),
+            ("minimum_c", self.minimum_c),
+            ("maximum_c", self.maximum_c),
+        ):
+            if value is not None and not math.isfinite(value):
+                raise ValueError(f"{name} must be finite when provided")
+
+        if (
+            self.minimum_c is not None
+            and self.maximum_c is not None
+            and self.minimum_c > self.maximum_c
+        ):
+            raise ValueError("minimum_c must be <= maximum_c")
+        if self.extrapolation != "clamp":
+            raise ValueError("Only endpoint-clamped extrapolation is supported")
+
+        if mode is SupplyTemperatureControlMode.FIXED:
+            if self.setpoint_c is None:
+                raise ValueError("Fixed control requires setpoint_c")
+            if points:
+                raise ValueError("Fixed control does not accept compensation points")
+        elif mode is SupplyTemperatureControlMode.SCHEDULED:
+            if self.setpoint_c is not None:
+                raise ValueError("Scheduled control receives its setpoint at runtime")
+            if points:
+                raise ValueError("Scheduled control does not accept compensation points")
+        else:
+            if self.setpoint_c is not None:
+                raise ValueError("Compensated control does not accept setpoint_c")
+            if len(points) < 2:
+                raise ValueError("Compensated control requires at least two points")
+
+
+def resolve_supply_temperature_setpoint(
+    control: SupplyTemperatureControl,
+    outdoor_temperature_c: float,
+    extract_temperature_c: float,
+    scheduled_setpoint_c: float | None = None,
+) -> float:
+    """Return the requested AHU supply-air temperature in degrees Celsius.
+
+    The requested setpoint is distinct from the actual delivered supply
+    temperature. Heat recovery, coil capacity, frost control, and disabled
+    cooling can make the requested condition unattainable.
+    """
+
+    if not isinstance(control, SupplyTemperatureControl):
+        raise TypeError("control must be a SupplyTemperatureControl")
+
+    mode = control.mode
+    if mode is SupplyTemperatureControlMode.FIXED:
+        requested_c = control.setpoint_c
+    elif mode is SupplyTemperatureControlMode.SCHEDULED:
+        if scheduled_setpoint_c is None:
+            raise ValueError("Scheduled control requires scheduled_setpoint_c")
+        if not math.isfinite(scheduled_setpoint_c):
+            raise ValueError("scheduled_setpoint_c must be finite")
+        requested_c = scheduled_setpoint_c
+    elif mode is SupplyTemperatureControlMode.OUTDOOR_COMPENSATED:
+        requested_c = _interpolate_compensation_curve(
+            control.points,
+            outdoor_temperature_c,
+            "outdoor_temperature_c",
+        )
+    else:
+        requested_c = _interpolate_compensation_curve(
+            control.points,
+            extract_temperature_c,
+            "extract_temperature_c",
+        )
+
+    if control.minimum_c is not None:
+        requested_c = max(control.minimum_c, requested_c)
+    if control.maximum_c is not None:
+        requested_c = min(control.maximum_c, requested_c)
+    return requested_c
+
+
+def _interpolate_compensation_curve(
+    points: tuple[CompensationPoint, ...],
+    reference_temperature_c: float,
+    input_name: str,
+) -> float:
+    if not math.isfinite(reference_temperature_c):
+        raise ValueError(f"{input_name} must be finite")
+
+    if reference_temperature_c <= points[0].reference_temperature_c:
+        return points[0].supply_temperature_c
+    if reference_temperature_c >= points[-1].reference_temperature_c:
+        return points[-1].supply_temperature_c
+
+    for lower, upper in zip(points, points[1:]):
+        if reference_temperature_c <= upper.reference_temperature_c:
+            fraction = (
+                (reference_temperature_c - lower.reference_temperature_c)
+                / (upper.reference_temperature_c - lower.reference_temperature_c)
+            )
+            return lower.supply_temperature_c + fraction * (
+                upper.supply_temperature_c - lower.supply_temperature_c
+            )
+
+    raise RuntimeError("Compensation interpolation failed")

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -273,9 +273,12 @@ class SensibleAHUConfig:
     """Configuration for the sensible EN 16798-5-1 AHU timestep model.
 
     Covers balanced scheduled CAV with sensible heat recovery,
-    EXHAUST_LIMIT frost protection, modulating-bypass economizer, and a
-    heating coil. Cooling coil support is not yet implemented;
-    ``cooling_coil_enabled`` must be False.
+    EXHAUST_LIMIT frost protection, modulating-bypass economizer, and
+    heating and cooling coils. Cooling is sensible only (no
+    dehumidification); set ``cooling_coil_enabled=True`` to deliver
+    mechanical cooling, optionally capped by ``cooling_coil_max_power_w``.
+    When the cooling coil is disabled, any cooling load is still reported
+    in ``required_cooling_coil_power_w`` as an unmet shortfall.
 
     Fan model:
       ``supply_fan_specific_power_w_per_m3_s`` and
@@ -302,6 +305,9 @@ class SensibleAHUConfig:
     extract_fan_specific_power_w_per_m3_s: float
     supply_fan_heat_fraction_to_air: float
     extract_fan_heat_fraction_to_air: float
+    # Cooling coil capacity [W]; None = unlimited. Ignored when
+    # cooling_coil_enabled is False. Mirrors heating_coil_max_power_w.
+    cooling_coil_max_power_w: float | None = None
     frost_exhaust_limit_c: float = -5.0
     fan_performance_model: FanPerformanceModel | str = FanPerformanceModel.EN16798_5_1
     supply_fan_design_pressure_pa: float | None = None
@@ -365,6 +371,15 @@ class SensibleAHUConfig:
                     "heating_coil_max_power_w must be finite and non-negative when provided"
                 )
 
+        if self.cooling_coil_max_power_w is not None:
+            if (
+                not math.isfinite(self.cooling_coil_max_power_w)
+                or self.cooling_coil_max_power_w < 0.0
+            ):
+                raise ValueError(
+                    "cooling_coil_max_power_w must be finite and non-negative when provided"
+                )
+
         for name, value in (
             ("supply_fan_specific_power_w_per_m3_s",
              self.supply_fan_specific_power_w_per_m3_s),
@@ -403,11 +418,6 @@ class SensibleAHUConfig:
 
         if not math.isfinite(self.frost_exhaust_limit_c):
             raise ValueError("frost_exhaust_limit_c must be finite")
-
-        if self.cooling_coil_enabled:
-            raise NotImplementedError(
-                "cooling_coil_enabled=True is not yet implemented; set to False"
-            )
 
 
 @dataclass(frozen=True)
@@ -497,13 +507,18 @@ class AHUStepOutputs:
                                     configurations because the effective HR outlet temperature
                                     is determined by a different algorithm.
                                     Positive in heating mode; negative in economizer mode.
-    required_heating_coil_power_w:  coil power needed to reach setpoint.
-    actual_heating_coil_power_w:    coil power actually delivered (≤ required).
-    required_cooling_coil_power_w:  cooling coil power that would be needed to reach the
-                                    setpoint but cannot be delivered (cooling_coil_enabled
-                                    is not yet implemented).  Non-zero when the requested
-                                    supply temperature is below the minimum achievable by
-                                    bypass alone.
+    required_heating_coil_power_w:  heating coil power needed to reach setpoint.
+    actual_heating_coil_power_w:    heating coil power actually delivered (≤ required).
+    required_cooling_coil_power_w:  sensible cooling coil power needed to pull the
+                                    post-HR/bypass supply air down to the setpoint.
+                                    Non-zero when the requested supply temperature is
+                                    below the minimum achievable by bypass alone.
+                                    Placed before the heating coil in the air path,
+                                    per EN 16798-5-1.
+    actual_cooling_coil_power_w:    cooling coil power actually delivered (≤ required).
+                                    Zero when cooling_coil_enabled is False — the
+                                    required value then reports the unmet shortfall.
+                                    Capacity-limited by cooling_coil_max_power_w.
     fan_electric_power_w:           total fan electrical power (separate from thermal).
     bypass_fraction:                effective fraction of the HR bypassed, derived from
                                     actual vs nominal recovery [0, 1].  Reflects efficiency
@@ -519,6 +534,7 @@ class AHUStepOutputs:
     required_heating_coil_power_w: float
     actual_heating_coil_power_w: float
     required_cooling_coil_power_w: float
+    actual_cooling_coil_power_w: float
     fan_electric_power_w: float
     heat_recovery_power_w: float
     bypass_fraction: float
@@ -616,10 +632,14 @@ def calculate_sensible_ahu_step(
         reach internal target; full bypass yields outdoor air, no bypass yields HR
         outlet.  Compute total bypass_fraction combining frost and modulation.
     7.  Compute heat recovery power (net thermal gain to supply vs outdoor).
-    8.  Compute required and actual heating-coil power; raise supply temperature.
+    8a. Compute required and actual cooling-coil power; lower supply temperature
+        toward the target.  When cooling is disabled the required value reports the
+        unmet shortfall and nothing is delivered.  Cooling precedes heating in the
+        air path, per EN 16798-5-1.
+    8b. Compute required and actual heating-coil power; raise supply temperature.
         Coil capacity applies while operating; required and delivered powers are
         then averaged over the timestep with operation_fraction.
-    9.  Add supply fan heat to supply after coil.
+    9.  Add supply fan heat to supply after the coils.
     10. Return AHUStepOutputs with all quantities separated.
 
     When operation_fraction, flow_fraction, or required supply flow is zero,
@@ -651,6 +671,7 @@ def calculate_sensible_ahu_step(
             required_heating_coil_power_w=0.0,
             actual_heating_coil_power_w=0.0,
             required_cooling_coil_power_w=0.0,
+            actual_cooling_coil_power_w=0.0,
             fan_electric_power_w=0.0,
             heat_recovery_power_w=0.0,
             bypass_fraction=0.0,
@@ -760,14 +781,35 @@ def calculate_sensible_ahu_step(
     # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
     hr_power_operating_w = rho_cp_q * (t_after_hr - t_outdoor)
 
-    # Unmet cooling: power that would be needed to reach t_target but cannot be
-    # delivered because no cooling coil is present.  Positive when bypass has been
-    # driven to its limit and the supply is still above the setpoint.
+    # Step 8a: Cooling coil — placed before the heating coil to follow the
+    # EN 16798-5-1 air path (the spreadsheet's cooling/dehumidification block,
+    # formulas around D111-D158, precedes the heating block at D129-D154).  In
+    # this sensible single-setpoint model the two coils are mutually exclusive
+    # within a timestep, so ordering does not change the result, but it keeps the
+    # sequence faithful to the standard and ready for a future dehumidification-
+    # reheat extension.
+    #
+    # required_cooling is the sensible load needed to pull the post-HR/bypass air
+    # down to t_target.  When the coil is disabled it is reported as the unmet
+    # cooling shortfall (actual delivered = 0); when enabled it is met up to the
+    # optional capacity limit.  This mirrors the heating coil below.
     required_cooling_operating_w = rho_cp_q * max(0.0, t_after_hr - t_target)
+    if not config.cooling_coil_enabled:
+        actual_cooling_operating_w = 0.0
+    elif config.cooling_coil_max_power_w is None:
+        actual_cooling_operating_w = required_cooling_operating_w
+    else:
+        actual_cooling_operating_w = min(
+            required_cooling_operating_w,
+            config.cooling_coil_max_power_w,
+        )
 
-    # Step 8: Heating coil targeting t_target so delivered temperature equals
-    # requested_t_sup after supply fan heat is added in step 9.
-    required_heating_operating_w = rho_cp_q * max(0.0, t_target - t_after_hr)
+    t_after_cooling = t_after_hr - actual_cooling_operating_w / rho_cp_q
+
+    # Step 8b: Heating coil targeting t_target so delivered temperature equals
+    # requested_t_sup after supply fan heat is added in step 9.  It sees the
+    # post-cooling temperature; with a single setpoint at most one coil is active.
+    required_heating_operating_w = rho_cp_q * max(0.0, t_target - t_after_cooling)
     if config.heating_coil_max_power_w is None:
         actual_heating_operating_w = required_heating_operating_w
     else:
@@ -776,9 +818,9 @@ def calculate_sensible_ahu_step(
             config.heating_coil_max_power_w,
         )
 
-    t_after_coil = t_after_hr + actual_heating_operating_w / rho_cp_q
+    t_after_coil = t_after_cooling + actual_heating_operating_w / rho_cp_q
 
-    # Step 9: Supply fan heat (after HR and coil, before zone delivery)
+    # Step 9: Supply fan heat (after HR and coils, before zone delivery)
     t_actual_supply = t_after_coil + dt_sup_fan
 
     return AHUStepOutputs(
@@ -789,6 +831,7 @@ def calculate_sensible_ahu_step(
         required_heating_coil_power_w=required_heating_operating_w * op,
         actual_heating_coil_power_w=actual_heating_operating_w * op,
         required_cooling_coil_power_w=required_cooling_operating_w * op,
+        actual_cooling_coil_power_w=actual_cooling_operating_w * op,
         fan_electric_power_w=fan_electric_power_w,
         heat_recovery_power_w=hr_power_operating_w * op,
         bypass_fraction=bypass_fraction,
@@ -802,6 +845,28 @@ def calculate_sensible_ahu_step(
 
 def _opt_float(v) -> "float | None":
     return None if v is None else float(v)
+
+
+def _parse_bool(v, *, key: str) -> bool:
+    """Parse a config flag robustly.
+
+    Native bools pass through; recognised strings are mapped explicitly so a
+    JSON/CSV value of ``"false"`` does not become ``True`` via ``bool("false")``.
+    """
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return bool(v)
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s in ("true", "1", "yes", "on"):
+            return True
+        if s in ("false", "0", "no", "off", ""):
+            return False
+    raise ValueError(
+        f"{key!r} must be a boolean or a recognised string "
+        f"(true/false/yes/no/on/off/1/0); got {v!r}"
+    )
 
 
 def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
@@ -827,10 +892,11 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
       ``frost_exhaust_limit_c``             — -5.0 [°C]
       ``heating_coil_max_power_w``          — None (unlimited)
       ``cooling_coil_enabled``              — False
+      ``cooling_coil_max_power_w``          — None (unlimited; ignored when disabled)
       ``supply_fan_specific_power_w_per_m3_s`` — 0.0  (nominal SFP at design flow)
       ``extract_fan_specific_power_w_per_m3_s`` — 0.0  (nominal SFP at design flow)
-      ``supply_fan_heat_fraction_to_air``   — 1.0
-      ``extract_fan_heat_fraction_to_air``  — 1.0
+      ``supply_fan_heat_fraction_to_air``   — 0.90
+      ``extract_fan_heat_fraction_to_air``  — 0.90
       ``fan_performance_model``              — "en16798_5_1"
       ``supply_fan_design_pressure_pa``      — derived from nominal SFP and efficiency
       ``extract_fan_design_pressure_pa``     — derived from nominal SFP and efficiency
@@ -842,6 +908,10 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
     heating_coil_max = d.get("heating_coil_max_power_w")
     if heating_coil_max is not None:
         heating_coil_max = float(heating_coil_max)
+
+    cooling_coil_max = d.get("cooling_coil_max_power_w")
+    if cooling_coil_max is not None:
+        cooling_coil_max = float(cooling_coil_max)
 
     ctrl_mode_str = str(d.get("supply_temperature_mode", "fixed")).strip().lower()
     if ctrl_mode_str in ("fixed", ""):
@@ -894,7 +964,10 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
         frost_control=str(d.get("frost_control", "exhaust_limit")),
         frost_exhaust_limit_c=float(d.get("frost_exhaust_limit_c", -5.0)),
         heating_coil_max_power_w=heating_coil_max,
-        cooling_coil_enabled=bool(d.get("cooling_coil_enabled", False)),
+        cooling_coil_enabled=_parse_bool(
+            d.get("cooling_coil_enabled", False), key="cooling_coil_enabled"
+        ),
+        cooling_coil_max_power_w=cooling_coil_max,
         supply_fan_specific_power_w_per_m3_s=float(
             d.get("supply_fan_specific_power_w_per_m3_s", 0.0)
         ),
@@ -902,10 +975,10 @@ def sensible_ahu_config_from_dict(d: dict) -> SensibleAHUConfig:
             d.get("extract_fan_specific_power_w_per_m3_s", 0.0)
         ),
         supply_fan_heat_fraction_to_air=float(
-            d.get("supply_fan_heat_fraction_to_air", 1.0)
+            d.get("supply_fan_heat_fraction_to_air", 0.90)
         ),
         extract_fan_heat_fraction_to_air=float(
-            d.get("extract_fan_heat_fraction_to_air", 1.0)
+            d.get("extract_fan_heat_fraction_to_air", 0.90)
         ),
         fan_performance_model=str(
             d.get("fan_performance_model", "en16798_5_1")

--- a/src/pybuildingenergy/source/ventilation_16798_5_1.py
+++ b/src/pybuildingenergy/source/ventilation_16798_5_1.py
@@ -6,9 +6,26 @@ calculation so that fixed, scheduled, outdoor-compensated, and
 extract-compensated supervisory controls share one explicit and testable
 interface.
 
-Only the supply-temperature controller is implemented in this first slice.
-Heat recovery, frost protection, coils, fans, and conversion to an ISO 52016
-ventilation stream are added separately.
+Standards note on extract-compensated control
+----------------------------------------------
+The EXTRACT_COMPENSATED controller computes a requested supply-temperature
+setpoint as a piecewise-linear function of zone (extract) air temperature.
+This is a supervisory strategy supported by the architecture of EN 16798-5-1
+but is NOT enumerated as one of the core controller modes in EN 16798-5-1
+Table B.2 (which covers fixed, outdoor-compensated, and load-compensated
+strategies). It is implemented here as a generic piecewise-linear controller
+that produces theta_SUP_req_zV for the AHU calculation.
+
+Physical constants
+------------------
+Standard air at sea level, approximately 20 °C:
+  rho = 1.204 kg/m³,  cp = 1005 J/(kg·K)  →  rho*cp = 1209 J/(m³·K)
+
+Fan heat placement
+------------------
+Extract fan heat is added to extract air BEFORE the heat exchanger, increasing
+the temperature of air entering the HR core. Supply fan heat is added to
+supply air AFTER the heat exchanger and heating coil, just before delivery.
 """
 
 from __future__ import annotations
@@ -17,6 +34,19 @@ from dataclasses import dataclass
 from enum import Enum
 import math
 
+
+# ---------------------------------------------------------------------------
+# Physical constants
+# ---------------------------------------------------------------------------
+
+_RHO_AIR_KG_M3: float = 1.204
+_CP_AIR_J_KG_K: float = 1005.0
+_RHO_CP_J_M3_K: float = _RHO_AIR_KG_M3 * _CP_AIR_J_KG_K  # 1209.0 J/(m³·K)
+
+
+# ---------------------------------------------------------------------------
+# Supply-temperature controller
+# ---------------------------------------------------------------------------
 
 class SupplyTemperatureControlMode(str, Enum):
     """Available supply-air temperature setpoint strategies."""
@@ -179,3 +209,322 @@ def _interpolate_compensation_curve(
             )
 
     raise RuntimeError("Compensation interpolation failed")
+
+
+# ---------------------------------------------------------------------------
+# AHU thermodynamic model
+# ---------------------------------------------------------------------------
+
+class HeatRecoveryControl(str, Enum):
+    """Available heat-recovery control strategies."""
+
+    ALWAYS_ON = "always_on"
+    MODULATING_BYPASS = "modulating_bypass"
+
+
+class FrostControlMode(str, Enum):
+    """Available frost-protection strategies."""
+
+    NONE = "none"
+    BYPASS = "bypass"
+
+
+@dataclass(frozen=True)
+class SensibleAHUConfig:
+    """Configuration for the sensible EN 16798-5-1 AHU timestep model.
+
+    Covers balanced scheduled CAV with sensible heat recovery, bypass frost
+    control, modulating-bypass economizer, and a heating coil. Cooling coil
+    support is reserved for future implementation; setting cooling_coil_enabled
+    to True is accepted but has no effect in this version.
+    """
+
+    sensible_heat_recovery_efficiency: float
+    supply_temperature_control: SupplyTemperatureControl
+    heat_recovery_control: HeatRecoveryControl | str
+    frost_control: FrostControlMode | str
+    heating_coil_max_power_w: float | None
+    cooling_coil_enabled: bool
+    supply_fan_specific_power_w_per_m3_s: float
+    extract_fan_specific_power_w_per_m3_s: float
+    supply_fan_heat_fraction_to_air: float
+    extract_fan_heat_fraction_to_air: float
+    frost_exhaust_limit_c: float = -5.0
+
+    def __post_init__(self) -> None:
+        try:
+            object.__setattr__(
+                self, "heat_recovery_control",
+                HeatRecoveryControl(self.heat_recovery_control),
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported heat_recovery_control: {self.heat_recovery_control!r}"
+            ) from exc
+
+        try:
+            object.__setattr__(
+                self, "frost_control",
+                FrostControlMode(self.frost_control),
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported frost_control: {self.frost_control!r}"
+            ) from exc
+
+        eta = self.sensible_heat_recovery_efficiency
+        if not math.isfinite(eta) or eta < 0.0 or eta > 1.0:
+            raise ValueError(
+                "sensible_heat_recovery_efficiency must be finite and in [0, 1]"
+            )
+
+        if not isinstance(self.supply_temperature_control, SupplyTemperatureControl):
+            raise TypeError(
+                "supply_temperature_control must be a SupplyTemperatureControl"
+            )
+
+        if self.heating_coil_max_power_w is not None:
+            if (
+                not math.isfinite(self.heating_coil_max_power_w)
+                or self.heating_coil_max_power_w <= 0.0
+            ):
+                raise ValueError(
+                    "heating_coil_max_power_w must be positive and finite when provided"
+                )
+
+        for name, value in (
+            ("supply_fan_specific_power_w_per_m3_s",
+             self.supply_fan_specific_power_w_per_m3_s),
+            ("extract_fan_specific_power_w_per_m3_s",
+             self.extract_fan_specific_power_w_per_m3_s),
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+
+        for name, value in (
+            ("supply_fan_heat_fraction_to_air", self.supply_fan_heat_fraction_to_air),
+            ("extract_fan_heat_fraction_to_air", self.extract_fan_heat_fraction_to_air),
+        ):
+            if not math.isfinite(value) or value < 0.0 or value > 1.0:
+                raise ValueError(f"{name} must be finite and in [0, 1]")
+
+        if not math.isfinite(self.frost_exhaust_limit_c):
+            raise ValueError("frost_exhaust_limit_c must be finite")
+
+
+@dataclass(frozen=True)
+class AHUStepInputs:
+    """Time-varying inputs for one AHU timestep."""
+
+    outdoor_temperature_c: float
+    extract_temperature_c: float
+    required_supply_flow_m3_h: float
+    required_extract_flow_m3_h: float
+    operation_fraction: float
+    timestep_hours: float
+    scheduled_setpoint_c: float | None = None
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("outdoor_temperature_c", self.outdoor_temperature_c),
+            ("extract_temperature_c", self.extract_temperature_c),
+        ):
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+
+        for name, value in (
+            ("required_supply_flow_m3_h", self.required_supply_flow_m3_h),
+            ("required_extract_flow_m3_h", self.required_extract_flow_m3_h),
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+
+        if (
+            not math.isfinite(self.operation_fraction)
+            or not (0.0 <= self.operation_fraction <= 1.0)
+        ):
+            raise ValueError("operation_fraction must be finite and in [0, 1]")
+
+        if not math.isfinite(self.timestep_hours) or self.timestep_hours <= 0.0:
+            raise ValueError("timestep_hours must be positive and finite")
+
+        if (
+            self.scheduled_setpoint_c is not None
+            and not math.isfinite(self.scheduled_setpoint_c)
+        ):
+            raise ValueError("scheduled_setpoint_c must be finite when provided")
+
+
+@dataclass(frozen=True)
+class AHUStepOutputs:
+    """Computed outputs for one AHU timestep.
+
+    Power quantities are in watts, averaged over the timestep. Energy for a
+    timestep is power_w * timestep_hours / 1000 kWh.
+
+    requested_supply_temperature_c: setpoint from the supply-temperature controller.
+    actual_supply_temperature_c:    delivered supply temperature including fan heat.
+    heat_recovery_power_w:          net sensible heat transferred to supply (positive).
+    required_heating_coil_power_w:  coil power needed to reach setpoint.
+    actual_heating_coil_power_w:    coil power actually delivered (≤ required).
+    fan_electric_power_w:           total fan electrical power (separate from thermal).
+    bypass_fraction:                fraction of airflow bypassing the HR core [0, 1].
+    frost_control_active:           True when HR efficiency was reduced for frost.
+    """
+
+    requested_supply_temperature_c: float
+    actual_supply_temperature_c: float
+    actual_supply_flow_m3_h: float
+    actual_extract_flow_m3_h: float
+    required_heating_coil_power_w: float
+    actual_heating_coil_power_w: float
+    fan_electric_power_w: float
+    heat_recovery_power_w: float
+    bypass_fraction: float
+    frost_control_active: bool
+
+
+def calculate_sensible_ahu_step(
+    config: SensibleAHUConfig,
+    inputs: AHUStepInputs,
+) -> AHUStepOutputs:
+    """Calculate one timestep of the sensible EN 16798-5-1 AHU model.
+
+    Calculation sequence
+    --------------------
+    1.  Resolve requested supply-temperature setpoint from config controller.
+    2.  Scale flows by operation_fraction (scheduled CAV, balanced).
+    3.  Compute fan electricity; add extract fan heat to extract before HR,
+        accumulate supply fan heat for addition after HR and coil.
+    4.  Apply bypass frost protection: reduce effective HR efficiency so the
+        exhaust leaving the HR stays at or above frost_exhaust_limit_c.
+    5.  Compute HR outlet temperature from outdoor and frost-limited efficiency.
+    6.  Apply modulating bypass (if configured) to track supply setpoint without
+        overshooting in either heating or economizer direction.
+    7.  Compute heat recovery power (net thermal gain to supply vs outdoor).
+    8.  Compute required and actual heating-coil power; raise supply temperature.
+    9.  Add supply fan heat to supply after coil.
+    10. Return AHUStepOutputs with all quantities separated.
+
+    When operation_fraction is zero or required supply flow is zero, all flow
+    and energy outputs are zero and actual supply temperature equals outdoor.
+    """
+    if not isinstance(config, SensibleAHUConfig):
+        raise TypeError("config must be a SensibleAHUConfig")
+    if not isinstance(inputs, AHUStepInputs):
+        raise TypeError("inputs must be an AHUStepInputs")
+
+    # Step 1: Resolve requested setpoint
+    requested_t_sup = resolve_supply_temperature_setpoint(
+        config.supply_temperature_control,
+        inputs.outdoor_temperature_c,
+        inputs.extract_temperature_c,
+        inputs.scheduled_setpoint_c,
+    )
+
+    # Step 2: Actual flows (balanced scheduled CAV)
+    op = inputs.operation_fraction
+    actual_supply_m3_h = op * inputs.required_supply_flow_m3_h
+    actual_extract_m3_h = op * inputs.required_extract_flow_m3_h
+    q_sup = actual_supply_m3_h / 3600.0  # m³/s
+    q_eta = actual_extract_m3_h / 3600.0  # m³/s
+
+    if q_sup <= 0.0:
+        return AHUStepOutputs(
+            requested_supply_temperature_c=requested_t_sup,
+            actual_supply_temperature_c=inputs.outdoor_temperature_c,
+            actual_supply_flow_m3_h=0.0,
+            actual_extract_flow_m3_h=0.0,
+            required_heating_coil_power_w=0.0,
+            actual_heating_coil_power_w=0.0,
+            fan_electric_power_w=0.0,
+            heat_recovery_power_w=0.0,
+            bypass_fraction=0.0,
+            frost_control_active=False,
+        )
+
+    rho_cp_q = _RHO_CP_J_M3_K * q_sup  # W/K for supply stream
+
+    # Step 3: Fan electricity and temperature rises
+    p_sup_fan = q_sup * config.supply_fan_specific_power_w_per_m3_s
+    p_eta_fan = q_eta * config.extract_fan_specific_power_w_per_m3_s
+    fan_electric_power_w = p_sup_fan + p_eta_fan
+
+    # Extract fan heat warms extract entering the HR
+    dt_eta_fan = (
+        p_eta_fan * config.extract_fan_heat_fraction_to_air / (_RHO_CP_J_M3_K * q_eta)
+        if q_eta > 0.0
+        else 0.0
+    )
+    # Supply fan heat is applied after coil (accumulated now, used at step 9)
+    dt_sup_fan = p_sup_fan * config.supply_fan_heat_fraction_to_air / rho_cp_q
+
+    t_outdoor = inputs.outdoor_temperature_c
+    t_ext_at_hr = inputs.extract_temperature_c + dt_eta_fan
+    eta_nom = config.sensible_heat_recovery_efficiency
+    dT = t_ext_at_hr - t_outdoor  # K; positive in heating mode
+
+    # Step 4: Bypass frost protection
+    # The exhaust leaving the HR (EHA) must stay >= frost_exhaust_limit_c.
+    # For balanced flow: T_EHA = T_extract_at_hr - eta * dT
+    # If T_EHA < limit, reduce eta so T_EHA exactly equals the limit.
+    frost_active = False
+    eta_eff = eta_nom
+    if (
+        config.frost_control is FrostControlMode.BYPASS
+        and eta_nom > 0.0
+        and abs(dT) > 1e-9
+    ):
+        t_eha = t_ext_at_hr - eta_nom * dT  # exhaust at HR outlet
+        if t_eha < config.frost_exhaust_limit_c:
+            frost_active = True
+            eta_frost = (t_ext_at_hr - config.frost_exhaust_limit_c) / dT
+            eta_eff = max(0.0, min(eta_nom, eta_frost))
+
+    # Step 5: HR outlet temperature (before modulation)
+    t_after_hr = t_outdoor + eta_eff * dT
+
+    # Step 6: Modulating bypass to track requested setpoint
+    # Bypass mixes raw outdoor air with HR output.  The formula
+    #   bp = (T_hr - T_set) / (T_hr - T_oda)
+    # applies in both heating mode (HR overshoots setpoint) and economizer
+    # mode (HR overcools below setpoint when T_oda > T_extract).
+    # Bypass is only triggered when T_set lies strictly between T_oda and T_hr.
+    bypass_fraction = 0.0
+    if config.heat_recovery_control is HeatRecoveryControl.MODULATING_BYPASS:
+        dT_hr_oda = t_after_hr - t_outdoor  # = eta_eff * dT
+        if abs(dT_hr_oda) > 1e-9:
+            t_low = min(t_outdoor, t_after_hr)
+            t_high = max(t_outdoor, t_after_hr)
+            if t_low < requested_t_sup < t_high:
+                bypass_fraction = (t_after_hr - requested_t_sup) / dT_hr_oda
+                bypass_fraction = max(0.0, min(1.0, bypass_fraction))
+                t_after_hr = requested_t_sup  # setpoint achieved by mixing
+
+    # Step 7: Heat recovery power (net thermal gain to supply vs outdoor air)
+    hr_power_w = rho_cp_q * (t_after_hr - t_outdoor)
+
+    # Step 8: Heating coil
+    required_heating_w = rho_cp_q * max(0.0, requested_t_sup - t_after_hr)
+    if config.heating_coil_max_power_w is None:
+        actual_heating_w = required_heating_w
+    else:
+        actual_heating_w = min(required_heating_w, config.heating_coil_max_power_w)
+
+    t_after_coil = t_after_hr + actual_heating_w / rho_cp_q
+
+    # Step 9: Supply fan heat (after HR and coil, before zone delivery)
+    t_actual_supply = t_after_coil + dt_sup_fan
+
+    return AHUStepOutputs(
+        requested_supply_temperature_c=requested_t_sup,
+        actual_supply_temperature_c=t_actual_supply,
+        actual_supply_flow_m3_h=actual_supply_m3_h,
+        actual_extract_flow_m3_h=actual_extract_m3_h,
+        required_heating_coil_power_w=required_heating_w,
+        actual_heating_coil_power_w=actual_heating_w,
+        fan_electric_power_w=fan_electric_power_w,
+        heat_recovery_power_w=hr_power_w,
+        bypass_fraction=bypass_fraction,
+        frost_control_active=frost_active,
+    )

--- a/src/pybuildingenergy/source/ventilation_chapter.md
+++ b/src/pybuildingenergy/source/ventilation_chapter.md
@@ -228,6 +228,7 @@ resolve_ventilation_boundary(
     altitude_m=None,
     c_air=1006.0,
     rho_air=1.204,
+    ahu_outputs_collector=None,
 ) -> VentilationBoundary
 ```
 
@@ -254,7 +255,7 @@ ventilation.  Each entry is a dict:
 ```python
 {
     "name": "infiltration",               # required, unique label
-    "ventilation_type": "constant_ach",   # "constant_ach" or "prescribed"
+    "ventilation_type": "constant_ach",   # "constant_ach", "prescribed" or "mechanical_supply"
     "profile": "ventilation_profile",     # optional — names a profile_df column
     # type-specific keys, e.g.:
     "air_changes_per_hour": 0.3,
@@ -278,7 +279,64 @@ AHU delivering 18 °C supply air):
 
 A `components` list may combine infiltration (no profile → always active) and mechanical
 supply (with profile → follows schedule), which is the practical purpose of the additive
-stream model and the contract required by the EN 16798-5-1 AHU module (PR 2).
+stream model and the contract used by the EN 16798-5-1 AHU module (section 4.6).
+
+### 4.6 The `mechanical_supply` component (EN 16798-5-1 sensible AHU)
+
+The `"mechanical_supply"` type replaces the externally known supply condition of
+`"prescribed"` with a physics-based per-timestep AHU calculation implemented in
+`ventilation_16798_5_1.py`: sensible heat recovery, modulating bypass, frost
+protection by exhaust-temperature limit, capacity-limited sensible heating and
+cooling coils, and fan electricity/fan heat. The calculation is solver-independent;
+its result enters the zone balance only as one additive stream with
+`H_k = rho_air · cp_air · q_supply` and `T_source,k` equal to the delivered supply
+temperature, so the §6.5.10 formulation above is unchanged.
+
+```python
+{
+    "name": "ahu",
+    "ventilation_type": "mechanical_supply",
+    "supply_flow_m3_h": 3600.0,                  # required; extract defaults to supply
+    "sensible_heat_recovery_efficiency": 0.784,  # required, in [0, 1]
+    "supply_temperature_setpoint_c": 18.0,       # required for the default "fixed" mode
+    # optional, with defaults:
+    # "supply_temperature_mode": "fixed" | "outdoor_compensated" | "extract_compensated",
+    # "supply_temperature_points": [[-20, 19], [15, 17]],   # for compensated modes
+    # "heat_recovery_control": "modulating_bypass",
+    # "frost_control": "exhaust_limit", "frost_exhaust_limit_c": -5.0,
+    # "heating_coil_max_power_w": None, "cooling_coil_enabled": False,
+    # "supply_fan_specific_power_w_per_m3_s": 0.0, "fan_performance_model": "en16798_5_1",
+    "profile": "ventilation_profile",
+}
+```
+
+Three behaviours of this component differ from the simpler types and are
+deliberate conventions:
+
+1. **Lagged extract-air coupling.** The extract-air temperature entering the
+   heat recovery is the zone *air-node* temperature from the previous timestep
+   (not the operative temperature). This avoids the algebraic loop
+   T_zone → T_extract → heat recovery/coils → T_supply → T_zone and preserves
+   the single-pass solver workflow.
+2. **Profile fractions are flow fractions.** A fractional profile value scales
+   the operating airflow continuously (reduced fan speed, with fan power
+   following the EN 16798-5-1 part-load relations). It is *not* ON/OFF
+   duty-cycle averaging. Values outside [0, 1] raise `ValueError`.
+3. **System energy is diagnostic, not a zone gain.** Coil and fan quantities
+   are exported as per-component hourly columns (`Q_ahu_coil*`, `Q_ahu_cool*`,
+   `Q_ahu_hr`, `P_ahu_fan`, `T_ahu_sup*`, `q_sup_m3h`, `q_ext_m3h`,
+   `ahu_bypass`, `ahu_frost`) but are not added to the zone energy balance —
+   the ventilation term already uses the conditioned supply temperature, so
+   adding coil energy on the zone side would double-count it.
+
+The initial scope is a sensible, balanced-airflow subset of EN 16798-5-1 with
+fixed air properties (`rho·cp = 1211.224 J/(m³·K)`, the existing module
+convention; no altitude correction). For the full implemented / simplified /
+not-included breakdown, the configuration-key reference, the diagnostic-column
+schema and the standards context, see
+[`docs/ventilation_ahu_audit.html`](../../../docs/ventilation_ahu_audit.html).
+The `"prescribed"` type remains available as the intermediate option when the
+supply temperature is known externally.
 
 ## 5. `internal_gains`
 

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -223,7 +223,7 @@ def _cfg(**kw) -> SensibleAHUConfig:
         sensible_heat_recovery_efficiency=0.75,
         supply_temperature_control=_FIXED_18,
         heat_recovery_control="modulating_bypass",
-        frost_control="bypass",
+        frost_control="exhaust_limit",
         heating_coil_max_power_w=None,
         cooling_coil_enabled=False,
         supply_fan_specific_power_w_per_m3_s=0.0,
@@ -317,6 +317,16 @@ def test_config_rejects_wrong_supply_temperature_control_type():
         _cfg(supply_temperature_control="fixed:18")
 
 
+def test_config_rejects_cooling_coil_enabled():
+    with pytest.raises(NotImplementedError, match="cooling_coil_enabled"):
+        _cfg(cooling_coil_enabled=True)
+
+
+def test_config_accepts_exhaust_limit_frost_control():
+    cfg = _cfg(frost_control="exhaust_limit")
+    assert cfg.frost_control is FrostControlMode.EXHAUST_LIMIT
+
+
 # ---------------------------------------------------------------------------
 # AHUStepInputs validation
 # ---------------------------------------------------------------------------
@@ -351,8 +361,14 @@ def test_inputs_rejects_non_finite_scheduled_setpoint():
         _inp(scheduled_setpoint_c=math.inf)
 
 
-def test_inputs_zero_extract_flow_accepted():
-    inp = _inp(required_extract_flow_m3_h=0.0)
+def test_inputs_unbalanced_flows_rejected():
+    with pytest.raises(ValueError, match="balanced-flow"):
+        _inp(required_extract_flow_m3_h=0.0)  # supply=1350, extract=0 — unbalanced
+
+
+def test_inputs_both_zero_flows_accepted():
+    inp = _inp(required_supply_flow_m3_h=0.0, required_extract_flow_m3_h=0.0)
+    assert inp.required_supply_flow_m3_h == 0.0
     assert inp.required_extract_flow_m3_h == 0.0
 
 
@@ -386,9 +402,19 @@ def test_zero_operation_produces_zero_flow_and_energy():
     assert not out.frost_control_active
 
 
-def test_zero_operation_still_resolves_requested_setpoint():
+def test_zero_operation_requested_setpoint_is_outdoor_temperature():
+    # AHU is off: no setpoint resolution; reported value is outdoor air temperature.
     out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
-    assert out.requested_supply_temperature_c == pytest.approx(18.0)
+    assert out.requested_supply_temperature_c == pytest.approx(-9.7)
+
+
+def test_scheduled_control_off_ahu_does_not_require_setpoint():
+    # Scheduled mode with no setpoint must not raise when AHU is off.
+    ctrl = SupplyTemperatureControl(mode="scheduled")
+    cfg = _cfg(supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=0.0))
+    assert out.actual_supply_flow_m3_h == 0.0
+    assert out.actual_heating_coil_power_w == pytest.approx(0.0)
 
 
 def test_zero_required_flow_equivalent_to_zero_operation():
@@ -456,8 +482,9 @@ def test_bypass_activates_when_hr_overshoots_setpoint_in_heating_mode():
     # T_outdoor=10, T_extract=22, eta=0.75 → T_hr=10+0.75*12=19°C > setpoint=16°C
     ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=16.0)
     cfg = _cfg(sensible_heat_recovery_efficiency=0.75, supply_temperature_control=ctrl)
-    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0))
-
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0)
+    )
     t_hr_full = 10.0 + 0.75 * 12.0  # 19.0°C
     expected_bp = (t_hr_full - 16.0) / (t_hr_full - 10.0)
     assert out.bypass_fraction == pytest.approx(expected_bp, rel=1e-6)
@@ -595,14 +622,44 @@ def test_no_heating_needed_when_hr_meets_setpoint_exactly():
     assert out.actual_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
 
 
+def test_coil_capacity_scales_with_operation_fraction():
+    """Time-averaged available coil power = rated_power * operation_fraction.
+
+    For ON/OFF scheduling the coil runs at rated power during the ON period.
+    The supply temperature rise during that period is coil_max / rho_cp_q_nominal,
+    identical to full operation — only the time-averaged energy differs.
+    """
+    # Choose coil_max < required_at_full so the coil is capacity-limited.
+    t_oda = -9.7
+    t_hr = t_oda + 0.75 * (21.0 - t_oda)  # 13.325°C (no bypass, setpoint > t_hr)
+    rho_cp_q_nom = _RHO_CP_J_M3_K * _Q_M3_S
+    required_at_full = rho_cp_q_nom * (18.0 - t_hr)  # ~2 233 W
+    coil_max = required_at_full * 0.6  # definitely capacity-limited at any op fraction
+
+    cfg = _cfg(heating_coil_max_power_w=coil_max)
+
+    out_full = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=1.0))
+    out_half = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=0.5))
+
+    # At full op: actual = coil_max * 1.0
+    assert out_full.actual_heating_coil_power_w == pytest.approx(coil_max, rel=1e-9)
+    # At half op: time-averaged actual = coil_max * 0.5
+    assert out_half.actual_heating_coil_power_w == pytest.approx(coil_max * 0.5, rel=1e-9)
+    # Supply temperature during the ON period is the same (coil_max / rho_cp_q_nom
+    # temperature rise regardless of duty cycle) — both ops reach the same T_supply.
+    assert out_half.actual_supply_temperature_c == pytest.approx(
+        out_full.actual_supply_temperature_c, abs=1e-6
+    )
+
+
 # ---------------------------------------------------------------------------
 # Cooling disabled — unattainable cold setpoints
 # ---------------------------------------------------------------------------
 
-def test_disabled_cooling_leaves_supply_at_hr_output_when_setpoint_below_outdoor():
-    # T_outdoor=5, T_extract=22, setpoint=2°C < T_outdoor — unattainable without cooling
-    # T_hr = 5 + 0.75*17 = 17.75°C; setpoint (2°C) is below T_outdoor (5°C)
-    # Neither bypass nor coil can cool; actual supply stays at T_hr
+def test_disabled_cooling_full_bypass_when_setpoint_below_outdoor():
+    # T_outdoor=5, T_extract=22, setpoint=2°C < T_outdoor — unattainable without cooling.
+    # MODULATING_BYPASS: bp = (17.75 - 2) / (17.75 - 5) = 1.235 → clamped to 1.0.
+    # Full bypass delivers T_outdoor (5°C); coil has nothing to do.
     ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=2.0)
     cfg = _cfg(
         sensible_heat_recovery_efficiency=0.75,
@@ -612,10 +669,9 @@ def test_disabled_cooling_leaves_supply_at_hr_output_when_setpoint_below_outdoor
     out = calculate_sensible_ahu_step(
         cfg, _inp(outdoor_temperature_c=5.0, extract_temperature_c=22.0)
     )
-    t_hr = 5.0 + 0.75 * (22.0 - 5.0)
-    assert out.actual_supply_temperature_c == pytest.approx(t_hr, rel=1e-6)
+    assert out.actual_supply_temperature_c == pytest.approx(5.0, abs=1e-6)
+    assert out.bypass_fraction == pytest.approx(1.0, abs=1e-9)
     assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
-    assert out.bypass_fraction == pytest.approx(0.0, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -667,8 +723,8 @@ def test_extract_fan_heat_zero_fraction_does_not_affect_hr():
     assert out_zero_frac.fan_electric_power_w > out_no_fan.fan_electric_power_w
 
 
-def test_supply_fan_heat_adds_to_supply_after_coil():
-    """Supply fan heat raises actual supply above setpoint."""
+def test_supply_fan_heat_absorbed_by_coil_target_adjustment():
+    """Coil targets setpoint minus fan heat rise so delivered equals setpoint."""
     sfp = 500.0
     p_sup = _Q_M3_S * sfp
     dt_sup = p_sup / (_RHO_CP_J_M3_K * _Q_M3_S)
@@ -679,8 +735,10 @@ def test_supply_fan_heat_adds_to_supply_after_coil():
     )
     out = calculate_sensible_ahu_step(cfg, _inp())
 
-    # Setpoint is 18°C; supply fan adds dt_sup on top
-    assert out.actual_supply_temperature_c == pytest.approx(18.0 + dt_sup, rel=1e-5)
+    # Fan is downstream of the coil; the coil targets setpoint - dt_sup so that
+    # actual delivered temperature equals the 18°C setpoint after fan heat.
+    assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-5)
+    assert out.fan_electric_power_w == pytest.approx(p_sup, rel=1e-9)
 
 
 def test_supply_fan_zero_heat_fraction_does_not_raise_supply():

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -863,7 +863,7 @@ def test_adapter_default_name_and_category():
     out = calculate_sensible_ahu_step(_cfg(), _inp())
     stream = ahu_outputs_to_ventilation_stream(out)
     assert stream.name == "mechanical_supply"
-    assert stream.category == "mechanical_supply"
+    assert stream.category == "supply"
 
 
 def test_adapter_custom_name():
@@ -901,15 +901,23 @@ def test_adapter_zero_flow_source_temperature_is_finite():
 
 
 def test_adapter_zone_heat_flow_formula():
-    """Verify Q_k = H_k * (T_source - T_zone) is consistent with stream fields."""
+    """VentilationBoundary source_term_w equals H_k * actual_supply_temperature_c.
+
+    Exercises the full coupling path: AHU step → stream → VentilationBoundary,
+    then verifies both source_term_w and sensible_heat_flow_w close correctly.
+    """
     out = calculate_sensible_ahu_step(_cfg(), _inp())
     stream = ahu_outputs_to_ventilation_stream(out)
+    boundary = VentilationBoundary((stream,))
     t_zone = 21.0
-    q_stream = stream.heat_transfer_coefficient_w_k * (stream.source_temperature_c - t_zone)
-    q_direct = _RHO_CP_J_M3_K * out.actual_supply_flow_m3_h / 3600.0 * (
-        out.actual_supply_temperature_c - t_zone
-    )
-    assert q_stream == pytest.approx(q_direct)
+
+    # S_ve must equal H_k * T_actual_supply (not outdoor or requested temperature)
+    expected_s_ve = stream.heat_transfer_coefficient_w_k * out.actual_supply_temperature_c
+    assert boundary.source_term_w == pytest.approx(expected_s_ve)
+
+    # Q_ve = H_ve * T_zone - S_ve; supply at 18 °C < zone 21 °C → positive Q_ve
+    expected_q_ve = stream.heat_transfer_coefficient_w_k * t_zone - expected_s_ve
+    assert boundary.sensible_heat_flow_w(t_zone) == pytest.approx(expected_q_ve)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -921,7 +921,7 @@ def test_adapter_zone_heat_flow_formula():
 
 
 # ---------------------------------------------------------------------------
-# Solver integration tests
+# Boundary integration tests (AHU → VentilationStream → VentilationBoundary)
 # ---------------------------------------------------------------------------
 
 def _infiltration_stream(t_outdoor_c: float, h_w_k: float = 50.0) -> VentilationStream:

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -323,9 +323,19 @@ def test_config_rejects_wrong_supply_temperature_control_type():
         _cfg(supply_temperature_control="fixed:18")
 
 
-def test_config_rejects_cooling_coil_enabled():
-    with pytest.raises(NotImplementedError, match="cooling_coil_enabled"):
-        _cfg(cooling_coil_enabled=True)
+def test_config_accepts_cooling_coil_enabled():
+    cfg = _cfg(cooling_coil_enabled=True)
+    assert cfg.cooling_coil_enabled is True
+
+
+def test_config_accepts_cooling_coil_max():
+    cfg = _cfg(cooling_coil_enabled=True, cooling_coil_max_power_w=2000.0)
+    assert cfg.cooling_coil_max_power_w == pytest.approx(2000.0)
+
+
+def test_config_rejects_negative_cooling_coil_max():
+    with pytest.raises(ValueError, match="cooling_coil_max_power_w"):
+        _cfg(cooling_coil_enabled=True, cooling_coil_max_power_w=-100.0)
 
 
 def test_config_accepts_exhaust_limit_frost_control():
@@ -676,7 +686,7 @@ def test_zero_coil_max_delivers_no_heat():
 
 
 # ---------------------------------------------------------------------------
-# Cooling disabled — unattainable cold setpoints
+# Cooling coil — delivery, capacity, and shortfall
 # ---------------------------------------------------------------------------
 
 def test_disabled_cooling_full_bypass_when_setpoint_below_outdoor():
@@ -698,12 +708,63 @@ def test_disabled_cooling_full_bypass_when_setpoint_below_outdoor():
     # Cooling shortfall: full bypass delivers T_outdoor=5°C; setpoint=2°C needs 3 K more
     expected_cooling = _rho_cp_q() * (5.0 - 2.0)
     assert out.required_cooling_coil_power_w == pytest.approx(expected_cooling, rel=1e-6)
+    # Disabled: required reports the shortfall but nothing is delivered.
+    assert out.actual_cooling_coil_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+def test_enabled_cooling_reaches_setpoint_below_outdoor():
+    # Same boundary as the disabled case, but with the cooling coil active the
+    # residual 3 K (after full bypass to T_outdoor=5°C) is removed to reach 2°C.
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=2.0)
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.75,
+        supply_temperature_control=ctrl,
+        cooling_coil_enabled=True,
+    )
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=5.0, extract_temperature_c=22.0)
+    )
+    expected_cooling = _rho_cp_q() * (5.0 - 2.0)
+    assert out.required_cooling_coil_power_w == pytest.approx(expected_cooling, rel=1e-6)
+    assert out.actual_cooling_coil_power_w == pytest.approx(expected_cooling, rel=1e-6)
+    assert out.actual_supply_temperature_c == pytest.approx(2.0, abs=1e-6)
+    assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+def test_cooling_capacity_limit_caps_delivered_power_and_supply():
+    # Cooling coil capped at 1 K worth of power: it removes 1 K of the 3 K
+    # required, so supply settles at 4°C and the required value still reports 3 K.
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=2.0)
+    coil_max = _rho_cp_q() * 1.0
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.75,
+        supply_temperature_control=ctrl,
+        cooling_coil_enabled=True,
+        cooling_coil_max_power_w=coil_max,
+    )
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=5.0, extract_temperature_c=22.0)
+    )
+    assert out.actual_cooling_coil_power_w == pytest.approx(coil_max, rel=1e-9)
+    assert out.required_cooling_coil_power_w == pytest.approx(
+        _rho_cp_q() * 3.0, rel=1e-6
+    )
+    assert out.actual_supply_temperature_c == pytest.approx(4.0, abs=1e-6)
 
 
 def test_cooling_unmet_load_zero_in_normal_heating_mode():
     # Normal winter: HR undershoots setpoint → heating coil needed, no cooling shortfall
     out = calculate_sensible_ahu_step(_cfg(), _inp())
     assert out.required_cooling_coil_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+def test_enabled_cooling_idle_in_heating_mode():
+    # Cooling coil enabled but boundary calls for heating: cooling stays at zero
+    # and the heating coil does the work — the two coils never co-activate.
+    out = calculate_sensible_ahu_step(_cfg(cooling_coil_enabled=True), _inp())
+    assert out.actual_cooling_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    assert out.required_cooling_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    assert out.actual_heating_coil_power_w > 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -1238,8 +1299,8 @@ def test_from_dict_defaults():
     assert cfg.cooling_coil_enabled is False
     assert cfg.supply_fan_specific_power_w_per_m3_s == pytest.approx(0.0)
     assert cfg.extract_fan_specific_power_w_per_m3_s == pytest.approx(0.0)
-    assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(1.0)
-    assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(1.0)
+    assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(0.90)
+    assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(0.90)
     assert cfg.fan_performance_model is FanPerformanceModel.EN16798_5_1
     assert cfg.supply_fan_nominal_efficiency == pytest.approx(0.72)
     assert cfg.extract_fan_nominal_efficiency == pytest.approx(0.78)

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -14,9 +14,11 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     SupplyTemperatureControl,
     SupplyTemperatureControlMode,
     _RHO_CP_J_M3_K,
+    ahu_outputs_to_ventilation_stream,
     calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
 )
+from pybuildingenergy.source.ventilation import VentilationStream
 
 
 def _point(reference_c, supply_c):
@@ -845,3 +847,66 @@ def test_partial_load_scales_all_power_outputs():
     assert out_half.required_heating_coil_power_w == pytest.approx(
         0.5 * out_full.required_heating_coil_power_w, rel=1e-6
     )
+
+
+# ---------------------------------------------------------------------------
+# VentilationStream adapter tests
+# ---------------------------------------------------------------------------
+
+def test_adapter_returns_ventilation_stream():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out)
+    assert isinstance(stream, VentilationStream)
+
+
+def test_adapter_default_name_and_category():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out)
+    assert stream.name == "mechanical_supply"
+    assert stream.category == "mechanical_supply"
+
+
+def test_adapter_custom_name():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out, name="ahu_zone_1")
+    assert stream.name == "ahu_zone_1"
+
+
+def test_adapter_conductance_matches_rho_cp_q():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out)
+    expected_h = _RHO_CP_J_M3_K * out.actual_supply_flow_m3_h / 3600.0
+    assert stream.heat_transfer_coefficient_w_k == pytest.approx(expected_h)
+
+
+def test_adapter_source_temperature_matches_actual_supply():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out)
+    assert stream.source_temperature_c == pytest.approx(out.actual_supply_temperature_c)
+
+
+def test_adapter_zero_flow_gives_zero_conductance():
+    """AHU off: H_k = 0 so stream contributes nothing to zone balance."""
+    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
+    assert out.actual_supply_flow_m3_h == 0.0
+    stream = ahu_outputs_to_ventilation_stream(out)
+    assert stream.heat_transfer_coefficient_w_k == 0.0
+
+
+def test_adapter_zero_flow_source_temperature_is_finite():
+    """Zero-conductance stream must still carry a finite source temperature."""
+    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
+    stream = ahu_outputs_to_ventilation_stream(out)
+    assert math.isfinite(stream.source_temperature_c)
+
+
+def test_adapter_zone_heat_flow_formula():
+    """Verify Q_k = H_k * (T_source - T_zone) is consistent with stream fields."""
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    stream = ahu_outputs_to_ventilation_stream(out)
+    t_zone = 21.0
+    q_stream = stream.heat_transfer_coefficient_w_k * (stream.source_temperature_c - t_zone)
+    q_direct = _RHO_CP_J_M3_K * out.actual_supply_flow_m3_h / 3600.0 * (
+        out.actual_supply_temperature_c - t_zone
+    )
+    assert q_stream == pytest.approx(q_direct)

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -1,0 +1,194 @@
+"""Tests for the solver-independent EN 16798-5-1 sensible AHU model."""
+
+import math
+
+import pytest
+
+from pybuildingenergy.source.ventilation_16798_5_1 import (
+    CompensationPoint,
+    SupplyTemperatureControl,
+    SupplyTemperatureControlMode,
+    resolve_supply_temperature_setpoint,
+)
+
+
+def _point(reference_c, supply_c):
+    return CompensationPoint(reference_c, supply_c)
+
+
+def test_fixed_supply_temperature_control():
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.FIXED,
+        setpoint_c=18.0,
+    )
+
+    assert resolve_supply_temperature_setpoint(control, -10.0, 22.0) == 18.0
+
+
+def test_scheduled_supply_temperature_control():
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.SCHEDULED,
+    )
+
+    assert (
+        resolve_supply_temperature_setpoint(
+            control,
+            outdoor_temperature_c=-10.0,
+            extract_temperature_c=22.0,
+            scheduled_setpoint_c=17.5,
+        )
+        == 17.5
+    )
+
+
+def test_scheduled_control_requires_runtime_setpoint():
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.SCHEDULED,
+    )
+
+    with pytest.raises(ValueError, match="requires scheduled_setpoint_c"):
+        resolve_supply_temperature_setpoint(control, -10.0, 22.0)
+
+
+def test_outdoor_compensation_interpolates_multiple_segments():
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.OUTDOOR_COMPENSATED,
+        points=(
+            _point(10.0, 18.0),
+            _point(-10.0, 22.0),
+            _point(0.0, 20.0),
+        ),
+    )
+
+    assert resolve_supply_temperature_setpoint(control, -5.0, 22.0) == 21.0
+    assert resolve_supply_temperature_setpoint(control, 5.0, 22.0) == 19.0
+
+
+@pytest.mark.parametrize(
+    ("extract_temperature_c", "expected_supply_temperature_c"),
+    [
+        (20.0, 19.0),
+        (21.0, 19.0),
+        (22.0, 18.0),
+        (23.0, 17.0),
+        (24.0, 17.0),
+    ],
+)
+def test_extract_compensation_matches_zeblab_curve(
+    extract_temperature_c,
+    expected_supply_temperature_c,
+):
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.EXTRACT_COMPENSATED,
+        points=(
+            _point(21.0, 19.0),
+            _point(23.0, 17.0),
+        ),
+    )
+
+    assert (
+        resolve_supply_temperature_setpoint(
+            control,
+            outdoor_temperature_c=-5.0,
+            extract_temperature_c=extract_temperature_c,
+        )
+        == expected_supply_temperature_c
+    )
+
+
+def test_compensation_limits_apply_after_interpolation():
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.OUTDOOR_COMPENSATED,
+        points=(
+            _point(-10.0, 25.0),
+            _point(10.0, 15.0),
+        ),
+        minimum_c=17.0,
+        maximum_c=21.0,
+    )
+
+    assert resolve_supply_temperature_setpoint(control, -10.0, 22.0) == 21.0
+    assert resolve_supply_temperature_setpoint(control, 10.0, 22.0) == 17.0
+
+
+def test_duplicate_compensation_reference_temperature_rejected():
+    with pytest.raises(ValueError, match="must be unique"):
+        SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.EXTRACT_COMPENSATED,
+            points=(
+                _point(21.0, 19.0),
+                _point(21.0, 17.0),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        SupplyTemperatureControlMode.OUTDOOR_COMPENSATED,
+        SupplyTemperatureControlMode.EXTRACT_COMPENSATED,
+    ],
+)
+def test_compensated_control_requires_two_points(mode):
+    with pytest.raises(ValueError, match="at least two points"):
+        SupplyTemperatureControl(
+            mode=mode,
+            points=(_point(21.0, 19.0),),
+        )
+
+
+def test_invalid_minimum_and_maximum_rejected():
+    with pytest.raises(ValueError, match="minimum_c must be <= maximum_c"):
+        SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.FIXED,
+            setpoint_c=18.0,
+            minimum_c=20.0,
+            maximum_c=19.0,
+        )
+
+
+def test_unsupported_extrapolation_rejected():
+    with pytest.raises(ValueError, match="endpoint-clamped"):
+        SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.EXTRACT_COMPENSATED,
+            points=(
+                _point(21.0, 19.0),
+                _point(23.0, 17.0),
+            ),
+            extrapolation="linear",
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [math.nan, math.inf, -math.inf],
+)
+def test_non_finite_compensation_input_rejected(bad_value):
+    control = SupplyTemperatureControl(
+        mode=SupplyTemperatureControlMode.EXTRACT_COMPENSATED,
+        points=(
+            _point(21.0, 19.0),
+            _point(23.0, 17.0),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="extract_temperature_c must be finite"):
+        resolve_supply_temperature_setpoint(control, -5.0, bad_value)
+
+
+def test_control_accepts_string_mode_and_freezes_sorted_points():
+    source_points = [
+        _point(23.0, 17.0),
+        _point(21.0, 19.0),
+    ]
+    control = SupplyTemperatureControl(
+        mode="extract_compensated",
+        points=source_points,
+    )
+    source_points.append(_point(25.0, 16.0))
+
+    assert control.mode is SupplyTemperatureControlMode.EXTRACT_COMPENSATED
+    assert tuple(point.reference_temperature_c for point in control.points) == (
+        21.0,
+        23.0,
+    )

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -18,7 +18,7 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
 )
-from pybuildingenergy.source.ventilation import VentilationStream
+from pybuildingenergy.source.ventilation import VentilationBoundary, VentilationStream
 
 
 def _point(reference_c, supply_c):
@@ -910,3 +910,145 @@ def test_adapter_zone_heat_flow_formula():
         out.actual_supply_temperature_c - t_zone
     )
     assert q_stream == pytest.approx(q_direct)
+
+
+# ---------------------------------------------------------------------------
+# Solver integration tests
+# ---------------------------------------------------------------------------
+
+def _infiltration_stream(t_outdoor_c: float, h_w_k: float = 50.0) -> VentilationStream:
+    """Outdoor-air infiltration stream at fixed conductance."""
+    return VentilationStream(
+        name="infiltration",
+        heat_transfer_coefficient_w_k=h_w_k,
+        source_temperature_c=t_outdoor_c,
+        category="outdoor_air",
+    )
+
+
+def test_integration_boundary_h_ve_is_sum_of_streams():
+    """VentilationBoundary H_ve equals infiltration plus AHU stream conductances."""
+    t_outdoor = -5.0
+    inf = _infiltration_stream(t_outdoor, h_w_k=50.0)
+    out = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=t_outdoor))
+    ahu = ahu_outputs_to_ventilation_stream(out)
+    bnd = VentilationBoundary([inf, ahu])
+
+    assert bnd.heat_transfer_coefficient_w_k == pytest.approx(
+        inf.heat_transfer_coefficient_w_k + ahu.heat_transfer_coefficient_w_k
+    )
+
+
+def test_integration_actual_supply_temperature_enters_s_ve():
+    """S_ve includes H_ahu * actual_supply_temperature_c, not the outdoor or requested value."""
+    t_outdoor = -5.0
+    t_zone = 21.0
+    inf = _infiltration_stream(t_outdoor, h_w_k=50.0)
+    out = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=t_outdoor))
+    ahu = ahu_outputs_to_ventilation_stream(out)
+    bnd = VentilationBoundary([inf, ahu])
+
+    expected_s_ve = (
+        inf.heat_transfer_coefficient_w_k * t_outdoor
+        + ahu.heat_transfer_coefficient_w_k * out.actual_supply_temperature_c
+    )
+    assert bnd.source_term_w == pytest.approx(expected_s_ve)
+
+    # Supply temperature is warmer than outdoor, so S_ve > H_ve * T_outdoor.
+    s_ve_if_outdoor = bnd.heat_transfer_coefficient_w_k * t_outdoor
+    assert bnd.source_term_w > s_ve_if_outdoor
+
+
+def test_integration_infiltration_active_when_ahu_off():
+    """With AHU off, infiltration stream still contributes its full conductance."""
+    t_outdoor = -5.0
+    inf = _infiltration_stream(t_outdoor, h_w_k=50.0)
+    out = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=t_outdoor,
+                                                    operation_fraction=0.0))
+    ahu_off = ahu_outputs_to_ventilation_stream(out)
+    bnd = VentilationBoundary([inf, ahu_off])
+
+    assert ahu_off.heat_transfer_coefficient_w_k == 0.0
+    assert bnd.heat_transfer_coefficient_w_k == pytest.approx(
+        inf.heat_transfer_coefficient_w_k
+    )
+    assert bnd.source_term_w == pytest.approx(
+        inf.heat_transfer_coefficient_w_k * t_outdoor
+    )
+
+
+def test_integration_ahu_off_does_not_affect_zone_heat_flow():
+    """When AHU is off, sensible_heat_flow_w equals infiltration-only heat flow."""
+    t_outdoor = -5.0
+    t_zone = 21.0
+    inf = _infiltration_stream(t_outdoor, h_w_k=50.0)
+
+    out_on = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=t_outdoor))
+    out_off = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=t_outdoor,
+                                                        operation_fraction=0.0))
+    bnd_on = VentilationBoundary([inf, ahu_outputs_to_ventilation_stream(out_on)])
+    bnd_off = VentilationBoundary([inf, ahu_outputs_to_ventilation_stream(out_off)])
+
+    # AHU off → boundary = infiltration only
+    assert bnd_off.sensible_heat_flow_w(t_zone) == pytest.approx(
+        inf.heat_transfer_coefficient_w_k * t_zone - inf.heat_transfer_coefficient_w_k * t_outdoor
+    )
+    # AHU on with supply at 18 °C < zone 21 °C: supply air removes additional
+    # heat from the zone (positive Q_ve increases), so total Q_ve is higher.
+    assert bnd_on.sensible_heat_flow_w(t_zone) > bnd_off.sensible_heat_flow_w(t_zone)
+
+
+def test_integration_previous_step_extract_temperature_pattern():
+    """Verify one-step-lag coupling: T_zone_prev is passed as extract_temperature_c.
+
+    The extract temperature only affects HR heat recovery, not zone balance algebra.
+    A warmer previous-step zone temperature increases HR output and reduces coil load.
+    """
+    t_outdoor = -5.0
+    t_zone_prev_cold = 18.0
+    t_zone_prev_warm = 24.0
+
+    out_cold = calculate_sensible_ahu_step(
+        _cfg(), _inp(outdoor_temperature_c=t_outdoor,
+                     extract_temperature_c=t_zone_prev_cold)
+    )
+    out_warm = calculate_sensible_ahu_step(
+        _cfg(), _inp(outdoor_temperature_c=t_outdoor,
+                     extract_temperature_c=t_zone_prev_warm)
+    )
+
+    # Warmer previous-step zone → more HR heat → less coil required
+    assert out_warm.heat_recovery_power_w > out_cold.heat_recovery_power_w
+    assert out_warm.required_heating_coil_power_w < out_cold.required_heating_coil_power_w
+
+
+def test_integration_s_ve_sign_convention_positive_is_heat_to_zone():
+    """Q_ve = H_ve*T_zone - S_ve; positive means heat leaving the zone.
+
+    When supply is colder than zone, net ventilation removes heat from zone
+    (positive Q_ve).  When supply is warmer than zone, net flow adds heat
+    (negative Q_ve = heat into zone).
+    """
+    t_outdoor = -5.0
+    t_zone = 21.0
+
+    # Supply at 18 °C < zone 21 °C → ventilation removes heat → positive Q_ve
+    out = calculate_sensible_ahu_step(
+        _cfg(), _inp(outdoor_temperature_c=t_outdoor)
+    )
+    ahu = ahu_outputs_to_ventilation_stream(out)
+    bnd = VentilationBoundary([ahu])
+    assert out.actual_supply_temperature_c < t_zone
+    assert bnd.sensible_heat_flow_w(t_zone) > 0.0
+
+    # Supply above zone → ventilation adds heat → negative Q_ve
+    out_hot = calculate_sensible_ahu_step(
+        _cfg(supply_temperature_control=SupplyTemperatureControl(
+            mode=SupplyTemperatureControlMode.FIXED, setpoint_c=30.0
+        )),
+        _inp(outdoor_temperature_c=t_outdoor)
+    )
+    ahu_hot = ahu_outputs_to_ventilation_stream(out_hot)
+    bnd_hot = VentilationBoundary([ahu_hot])
+    assert out_hot.actual_supply_temperature_c > t_zone
+    assert bnd_hot.sensible_heat_flow_w(t_zone) < 0.0

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -297,9 +297,9 @@ def test_config_rejects_fan_fraction_above_one():
         _cfg(supply_fan_heat_fraction_to_air=1.1)
 
 
-def test_config_rejects_zero_heating_coil_max():
-    with pytest.raises(ValueError, match="heating_coil_max_power_w"):
-        _cfg(heating_coil_max_power_w=0.0)
+def test_config_accepts_zero_heating_coil_max():
+    cfg = _cfg(heating_coil_max_power_w=0.0)
+    assert cfg.heating_coil_max_power_w == 0.0
 
 
 def test_config_rejects_negative_heating_coil_max():
@@ -399,13 +399,13 @@ def test_zero_operation_produces_zero_flow_and_energy():
     assert out.required_heating_coil_power_w == 0.0
     assert out.actual_heating_coil_power_w == 0.0
     assert out.bypass_fraction == 0.0
-    assert not out.frost_control_active
+    assert not out.frost_protection_required
 
 
-def test_zero_operation_requested_setpoint_is_outdoor_temperature():
-    # AHU is off: no setpoint resolution; reported value is outdoor air temperature.
+def test_zero_operation_requested_setpoint_is_none():
+    # AHU is off: no setpoint resolved; None signals "not applicable".
     out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
-    assert out.requested_supply_temperature_c == pytest.approx(-9.7)
+    assert out.requested_supply_temperature_c is None
 
 
 def test_scheduled_control_off_ahu_does_not_require_setpoint():
@@ -553,7 +553,7 @@ def test_frost_control_activates_when_exhaust_would_freeze():
         _cfg(frost_exhaust_limit_c=-5.0),
         _inp(outdoor_temperature_c=-15.0, extract_temperature_c=21.0),
     )
-    assert out.frost_control_active
+    assert out.frost_protection_required
 
 
 def test_frost_control_reduces_hr_efficiency_to_keep_exhaust_at_limit():
@@ -579,14 +579,14 @@ def test_frost_control_not_active_when_exhaust_above_limit():
         _cfg(frost_exhaust_limit_c=-5.0),
         _inp(outdoor_temperature_c=-5.0, extract_temperature_c=21.0),
     )
-    assert not out.frost_control_active
+    assert not out.frost_protection_required
 
 
 def test_frost_mode_none_never_activates():
     cfg = _cfg(frost_control="none", sensible_heat_recovery_efficiency=0.9)
     # Very cold outdoor, would normally trigger frost
     out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=-20.0))
-    assert not out.frost_control_active
+    assert not out.frost_protection_required
 
 
 # ---------------------------------------------------------------------------
@@ -652,6 +652,13 @@ def test_coil_capacity_scales_with_operation_fraction():
     )
 
 
+def test_zero_coil_max_delivers_no_heat():
+    cfg = _cfg(heating_coil_max_power_w=0.0)
+    out = calculate_sensible_ahu_step(cfg, _inp())
+    assert out.actual_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    assert out.required_heating_coil_power_w > 0.0  # coil is needed but absent
+
+
 # ---------------------------------------------------------------------------
 # Cooling disabled — unattainable cold setpoints
 # ---------------------------------------------------------------------------
@@ -672,6 +679,15 @@ def test_disabled_cooling_full_bypass_when_setpoint_below_outdoor():
     assert out.actual_supply_temperature_c == pytest.approx(5.0, abs=1e-6)
     assert out.bypass_fraction == pytest.approx(1.0, abs=1e-9)
     assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    # Cooling shortfall: full bypass delivers T_outdoor=5°C; setpoint=2°C needs 3 K more
+    expected_cooling = _rho_cp_q() * (5.0 - 2.0)
+    assert out.required_cooling_coil_power_w == pytest.approx(expected_cooling, rel=1e-6)
+
+
+def test_cooling_unmet_load_zero_in_normal_heating_mode():
+    # Normal winter: HR undershoots setpoint → heating coil needed, no cooling shortfall
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    assert out.required_cooling_coil_power_w == pytest.approx(0.0, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -6,7 +6,6 @@ import pytest
 
 from pybuildingenergy.source.ventilation_16798_5_1 import (
     AHUStepInputs,
-    AHUStepOutputs,
     CompensationPoint,
     FanPerformanceModel,
     FrostControlMode,
@@ -15,7 +14,6 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     SupplyTemperatureControl,
     SupplyTemperatureControlMode,
     _RHO_CP_J_M3_K,
-    _opt_float,
     ahu_outputs_to_ventilation_stream,
     calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
@@ -29,7 +27,7 @@ def _point(reference_c, supply_c):
 
 
 # ---------------------------------------------------------------------------
-# Supply-temperature controller tests (existing)
+# Supply-temperature controller tests
 # ---------------------------------------------------------------------------
 
 def test_fixed_supply_temperature_control():
@@ -90,7 +88,7 @@ def test_outdoor_compensation_interpolates_multiple_segments():
         (24.0, 17.0),
     ],
 )
-def test_extract_compensation_matches_zeblab_curve(
+def test_extract_compensation_interpolates_and_clamps(
     extract_temperature_c,
     expected_supply_temperature_c,
 ):
@@ -248,7 +246,6 @@ def _inp(**kw) -> AHUStepInputs:
         required_supply_flow_m3_h=_Q_M3_H,
         required_extract_flow_m3_h=_Q_M3_H,
         operation_fraction=1.0,
-        timestep_hours=1.0,
     )
     defaults.update(kw)
     return AHUStepInputs(**defaults)
@@ -268,128 +265,56 @@ def test_config_accepts_string_enum_values():
     assert cfg.frost_control is FrostControlMode.NONE
 
 
-def test_config_rejects_unknown_heat_recovery_control():
-    with pytest.raises(ValueError, match="heat_recovery_control"):
-        _cfg(heat_recovery_control="turbo")
-
-
-def test_config_rejects_unknown_frost_control():
-    with pytest.raises(ValueError, match="frost_control"):
-        _cfg(frost_control="preheat")
-
-
-def test_config_rejects_efficiency_above_one():
-    with pytest.raises(ValueError, match="sensible_heat_recovery_efficiency"):
-        _cfg(sensible_heat_recovery_efficiency=1.01)
-
-
-def test_config_rejects_negative_efficiency():
-    with pytest.raises(ValueError, match="sensible_heat_recovery_efficiency"):
-        _cfg(sensible_heat_recovery_efficiency=-0.1)
-
-
-def test_config_rejects_non_finite_efficiency():
-    with pytest.raises(ValueError):
-        _cfg(sensible_heat_recovery_efficiency=math.nan)
-
-
-def test_config_rejects_negative_fan_power():
-    with pytest.raises(ValueError, match="supply_fan_specific_power"):
-        _cfg(supply_fan_specific_power_w_per_m3_s=-1.0)
-
-
-def test_config_rejects_fan_fraction_above_one():
-    with pytest.raises(ValueError, match="supply_fan_heat_fraction"):
-        _cfg(supply_fan_heat_fraction_to_air=1.1)
-
-
-def test_config_accepts_zero_heating_coil_max():
-    cfg = _cfg(heating_coil_max_power_w=0.0)
-    assert cfg.heating_coil_max_power_w == 0.0
-
-
-def test_config_rejects_negative_heating_coil_max():
-    with pytest.raises(ValueError, match="heating_coil_max_power_w"):
-        _cfg(heating_coil_max_power_w=-100.0)
-
-
-def test_config_none_heating_coil_max_accepted():
-    cfg = _cfg(heating_coil_max_power_w=None)
-    assert cfg.heating_coil_max_power_w is None
-
-
-def test_config_rejects_wrong_supply_temperature_control_type():
-    with pytest.raises(TypeError, match="supply_temperature_control"):
-        _cfg(supply_temperature_control="fixed:18")
-
-
-def test_config_accepts_cooling_coil_enabled():
-    cfg = _cfg(cooling_coil_enabled=True)
-    assert cfg.cooling_coil_enabled is True
-
-
-def test_config_accepts_cooling_coil_max():
-    cfg = _cfg(cooling_coil_enabled=True, cooling_coil_max_power_w=2000.0)
-    assert cfg.cooling_coil_max_power_w == pytest.approx(2000.0)
-
-
-def test_config_rejects_negative_cooling_coil_max():
-    with pytest.raises(ValueError, match="cooling_coil_max_power_w"):
-        _cfg(cooling_coil_enabled=True, cooling_coil_max_power_w=-100.0)
-
-
-def test_config_accepts_exhaust_limit_frost_control():
-    cfg = _cfg(frost_control="exhaust_limit")
-    assert cfg.frost_control is FrostControlMode.EXHAUST_LIMIT
+@pytest.mark.parametrize(
+    ("kwargs", "exc_type", "match"),
+    [
+        ({"heat_recovery_control": "turbo"}, ValueError, "heat_recovery_control"),
+        ({"frost_control": "preheat"}, ValueError, "frost_control"),
+        ({"sensible_heat_recovery_efficiency": 1.01}, ValueError, "sensible_heat_recovery_efficiency"),
+        ({"sensible_heat_recovery_efficiency": -0.1}, ValueError, "sensible_heat_recovery_efficiency"),
+        ({"sensible_heat_recovery_efficiency": math.nan}, ValueError, None),
+        ({"supply_fan_specific_power_w_per_m3_s": -1.0}, ValueError, "supply_fan_specific_power"),
+        ({"supply_fan_heat_fraction_to_air": 1.1}, ValueError, "supply_fan_heat_fraction"),
+        ({"heating_coil_max_power_w": -100.0}, ValueError, "heating_coil_max_power_w"),
+        ({"cooling_coil_enabled": True, "cooling_coil_max_power_w": -100.0}, ValueError, "cooling_coil_max_power_w"),
+        ({"supply_temperature_control": "fixed:18"}, TypeError, "supply_temperature_control"),
+    ],
+)
+def test_config_rejects_invalid_input(kwargs, exc_type, match):
+    with pytest.raises(exc_type, match=match):
+        _cfg(**kwargs)
 
 
 # ---------------------------------------------------------------------------
 # AHUStepInputs validation
 # ---------------------------------------------------------------------------
 
-def test_inputs_rejects_negative_flow():
-    with pytest.raises(ValueError, match="required_supply_flow_m3_h"):
-        _inp(required_supply_flow_m3_h=-100.0)
+def test_inputs_default_to_full_timestep_operation():
+    inp = AHUStepInputs(
+        outdoor_temperature_c=-5.0,
+        extract_temperature_c=21.0,
+        required_supply_flow_m3_h=3600.0,
+        required_extract_flow_m3_h=3600.0,
+    )
+    assert inp.operation_fraction == pytest.approx(1.0)
 
 
-def test_inputs_rejects_operation_fraction_above_one():
-    with pytest.raises(ValueError, match="operation_fraction"):
-        _inp(operation_fraction=1.5)
-
-
-def test_inputs_rejects_negative_operation_fraction():
-    with pytest.raises(ValueError, match="operation_fraction"):
-        _inp(operation_fraction=-0.1)
-
-
-def test_inputs_rejects_flow_fraction_above_one():
-    with pytest.raises(ValueError, match="flow_fraction"):
-        _inp(flow_fraction=1.1)
-
-
-def test_inputs_rejects_negative_flow_fraction():
-    with pytest.raises(ValueError, match="flow_fraction"):
-        _inp(flow_fraction=-0.1)
-
-
-def test_inputs_rejects_zero_timestep():
-    with pytest.raises(ValueError, match="timestep_hours"):
-        _inp(timestep_hours=0.0)
-
-
-def test_inputs_rejects_non_finite_outdoor_temperature():
-    with pytest.raises(ValueError, match="outdoor_temperature_c"):
-        _inp(outdoor_temperature_c=math.nan)
-
-
-def test_inputs_rejects_non_finite_scheduled_setpoint():
-    with pytest.raises(ValueError, match="scheduled_setpoint_c"):
-        _inp(scheduled_setpoint_c=math.inf)
-
-
-def test_inputs_unbalanced_flows_rejected():
-    with pytest.raises(ValueError, match="balanced-flow"):
-        _inp(required_extract_flow_m3_h=0.0)  # supply=1350, extract=0 — unbalanced
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"required_supply_flow_m3_h": -100.0}, "required_supply_flow_m3_h"),
+        ({"operation_fraction": 1.5}, "operation_fraction"),
+        ({"operation_fraction": -0.1}, "operation_fraction"),
+        ({"flow_fraction": 1.1}, "flow_fraction"),
+        ({"flow_fraction": -0.1}, "flow_fraction"),
+        ({"outdoor_temperature_c": math.nan}, "outdoor_temperature_c"),
+        ({"scheduled_setpoint_c": math.inf}, "scheduled_setpoint_c"),
+        ({"required_extract_flow_m3_h": 0.0}, "balanced-flow"),
+    ],
+)
+def test_inputs_rejects_invalid(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        _inp(**kwargs)
 
 
 def test_inputs_both_zero_flows_accepted():
@@ -402,12 +327,9 @@ def test_inputs_both_zero_flows_accepted():
 # calculate_sensible_ahu_step: type guards
 # ---------------------------------------------------------------------------
 
-def test_rejects_non_config():
+def test_step_type_guards():
     with pytest.raises(TypeError, match="config"):
         calculate_sensible_ahu_step("not a config", _inp())
-
-
-def test_rejects_non_inputs():
     with pytest.raises(TypeError, match="inputs"):
         calculate_sensible_ahu_step(_cfg(), "not inputs")
 
@@ -667,12 +589,8 @@ def test_coil_capacity_scales_with_operation_fraction():
     out_full = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=1.0))
     out_half = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=0.5))
 
-    # At full op: actual = coil_max * 1.0
     assert out_full.actual_heating_coil_power_w == pytest.approx(coil_max, rel=1e-9)
-    # At half op: time-averaged actual = coil_max * 0.5
     assert out_half.actual_heating_coil_power_w == pytest.approx(coil_max * 0.5, rel=1e-9)
-    # Supply temperature during the ON period is the same (coil_max / rho_cp_q_nom
-    # temperature rise regardless of duty cycle) — both ops reach the same T_supply.
     assert out_half.actual_supply_temperature_c == pytest.approx(
         out_full.actual_supply_temperature_c, abs=1e-6
     )
@@ -872,7 +790,7 @@ def test_fan_electricity_zero_when_no_fans_configured():
 
 
 def test_en16798_fan_part_load_matches_reference_relations():
-    """Pressure follows r² and efficiency follows sqrt(r), as in recirc."""
+    """Part-load pressure follows r² and fan efficiency follows sqrt(r)."""
     flow_fraction = 0.25
     sfp = 500.0
     cfg = _cfg(
@@ -902,7 +820,7 @@ def test_en16798_fan_part_load_matches_reference_relations():
     assert dt_part == pytest.approx(dt_design * flow_fraction ** 1.5, rel=1e-9)
 
 
-def test_en16798_fan_explicit_product_data_matches_recirc_equations():
+def test_en16798_fan_explicit_product_data_matches_part_load_equations():
     flow_fraction = 0.4
     design_pressure_pa = 500.0
     eta_nom = 0.72
@@ -1062,50 +980,26 @@ def test_partial_load_scales_all_power_outputs():
 # VentilationStream adapter tests
 # ---------------------------------------------------------------------------
 
-def test_adapter_returns_ventilation_stream():
+def test_adapter_stream_attributes():
+    """Adapter produces a VentilationStream with correct type, name, category, and physics."""
     out = calculate_sensible_ahu_step(_cfg(), _inp())
     stream = ahu_outputs_to_ventilation_stream(out)
     assert isinstance(stream, VentilationStream)
-
-
-def test_adapter_default_name_and_category():
-    out = calculate_sensible_ahu_step(_cfg(), _inp())
-    stream = ahu_outputs_to_ventilation_stream(out)
     assert stream.name == "mechanical_supply"
     assert stream.category == "supply"
-
-
-def test_adapter_custom_name():
-    out = calculate_sensible_ahu_step(_cfg(), _inp())
-    stream = ahu_outputs_to_ventilation_stream(out, name="ahu_zone_1")
-    assert stream.name == "ahu_zone_1"
-
-
-def test_adapter_conductance_matches_rho_cp_q():
-    out = calculate_sensible_ahu_step(_cfg(), _inp())
-    stream = ahu_outputs_to_ventilation_stream(out)
-    expected_h = _RHO_CP_J_M3_K * out.actual_supply_flow_m3_h / 3600.0
-    assert stream.heat_transfer_coefficient_w_k == pytest.approx(expected_h)
-
-
-def test_adapter_source_temperature_matches_actual_supply():
-    out = calculate_sensible_ahu_step(_cfg(), _inp())
-    stream = ahu_outputs_to_ventilation_stream(out)
+    assert stream.heat_transfer_coefficient_w_k == pytest.approx(
+        _RHO_CP_J_M3_K * out.actual_supply_flow_m3_h / 3600.0
+    )
     assert stream.source_temperature_c == pytest.approx(out.actual_supply_temperature_c)
+    named = ahu_outputs_to_ventilation_stream(out, name="ahu_zone_1")
+    assert named.name == "ahu_zone_1"
 
 
-def test_adapter_zero_flow_gives_zero_conductance():
-    """AHU off: H_k = 0 so stream contributes nothing to zone balance."""
+def test_adapter_zero_flow():
+    """AHU off: H_k=0 so stream contributes nothing; source_temperature_c stays finite."""
     out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
-    assert out.actual_supply_flow_m3_h == 0.0
     stream = ahu_outputs_to_ventilation_stream(out)
     assert stream.heat_transfer_coefficient_w_k == 0.0
-
-
-def test_adapter_zero_flow_source_temperature_is_finite():
-    """Zero-conductance stream must still carry a finite source temperature."""
-    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
-    stream = ahu_outputs_to_ventilation_stream(out)
     assert math.isfinite(stream.source_temperature_c)
 
 
@@ -1239,7 +1133,7 @@ def test_integration_previous_step_extract_temperature_pattern():
     assert out_warm.required_heating_coil_power_w < out_cold.required_heating_coil_power_w
 
 
-def test_integration_s_ve_sign_convention_positive_is_heat_to_zone():
+def test_integration_q_ve_sign_convention_positive_is_heat_leaving_zone():
     """Q_ve = H_ve*T_zone - S_ve; positive means heat leaving the zone.
 
     When supply is colder than zone, net ventilation removes heat from zone
@@ -1363,7 +1257,6 @@ def test_from_dict_produces_runnable_config():
         required_supply_flow_m3_h=3600.0,
         required_extract_flow_m3_h=3600.0,
         operation_fraction=1.0,
-        timestep_hours=1.0,
     )
     out = calculate_sensible_ahu_step(cfg, inp)
     assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
@@ -1371,7 +1264,7 @@ def test_from_dict_produces_runnable_config():
 
 def test_from_dict_outdoor_compensated_mode():
     """outdoor_compensated mode with two-point curve."""
-    # Points: T_oda=-20 → T_sup=19, T_oda=+15 → T_sup=17 (ZEBlab-like curve)
+    # Points: T_oda=-20 → T_sup=19, T_oda=+15 → T_sup=17
     cfg = sensible_ahu_config_from_dict({
         "sensible_heat_recovery_efficiency": 0.784,
         "supply_temperature_mode": "outdoor_compensated",
@@ -1394,7 +1287,6 @@ def test_from_dict_outdoor_compensated_delivers_interpolated_setpoint():
         required_supply_flow_m3_h=3600.0,
         required_extract_flow_m3_h=3600.0,
         operation_fraction=1.0,
-        timestep_hours=1.0,
     )
     out = calculate_sensible_ahu_step(cfg, inp)
     expected_setpoint = 17.0 + (15.0 - 0.0) / (15.0 - (-20.0)) * (19.0 - 17.0)
@@ -1418,12 +1310,3 @@ def test_from_dict_unknown_mode_raises():
             "supply_temperature_mode": "magic",
             "supply_temperature_setpoint_c": 18.0,
         })
-
-
-def test_opt_float_returns_none_for_none():
-    assert _opt_float(None) is None
-
-
-def test_opt_float_converts_numeric():
-    assert _opt_float(17.5) == pytest.approx(17.5)
-    assert _opt_float("18") == pytest.approx(18.0)

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -8,6 +8,7 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     AHUStepInputs,
     AHUStepOutputs,
     CompensationPoint,
+    FanPerformanceModel,
     FrostControlMode,
     HeatRecoveryControl,
     SensibleAHUConfig,
@@ -234,6 +235,7 @@ def _cfg(**kw) -> SensibleAHUConfig:
         extract_fan_specific_power_w_per_m3_s=0.0,
         supply_fan_heat_fraction_to_air=1.0,
         extract_fan_heat_fraction_to_air=0.0,
+        fan_performance_model="en16798_5_1",
     )
     defaults.update(kw)
     return SensibleAHUConfig(**defaults)
@@ -348,6 +350,16 @@ def test_inputs_rejects_operation_fraction_above_one():
 def test_inputs_rejects_negative_operation_fraction():
     with pytest.raises(ValueError, match="operation_fraction"):
         _inp(operation_fraction=-0.1)
+
+
+def test_inputs_rejects_flow_fraction_above_one():
+    with pytest.raises(ValueError, match="flow_fraction"):
+        _inp(flow_fraction=1.1)
+
+
+def test_inputs_rejects_negative_flow_fraction():
+    with pytest.raises(ValueError, match="flow_fraction"):
+        _inp(flow_fraction=-0.1)
 
 
 def test_inputs_rejects_zero_timestep():
@@ -798,6 +810,140 @@ def test_fan_electricity_zero_when_no_fans_configured():
     assert out.fan_electric_power_w == pytest.approx(0.0, abs=1e-9)
 
 
+def test_en16798_fan_part_load_matches_reference_relations():
+    """Pressure follows r² and efficiency follows sqrt(r), as in recirc."""
+    flow_fraction = 0.25
+    sfp = 500.0
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.0,
+        heating_coil_max_power_w=0.0,
+        supply_fan_specific_power_w_per_m3_s=sfp,
+        supply_fan_heat_fraction_to_air=1.0,
+        fan_performance_model="en16798_5_1",
+    )
+
+    out_design = calculate_sensible_ahu_step(cfg, _inp())
+    out_part = calculate_sensible_ahu_step(
+        cfg,
+        _inp(flow_fraction=flow_fraction),
+    )
+
+    # With q_ref=q_design and eta_ref=eta_nom:
+    # P/P_design = r * r² / sqrt(r) = r**2.5.
+    assert out_part.fan_electric_power_w == pytest.approx(
+        out_design.fan_electric_power_w * flow_fraction ** 2.5,
+        rel=1e-9,
+    )
+
+    dt_design = out_design.actual_supply_temperature_c - (-9.7)
+    dt_part = out_part.actual_supply_temperature_c - (-9.7)
+    # Delta-T = delta_p/(rho*cp*eta), hence r²/sqrt(r) = r**1.5.
+    assert dt_part == pytest.approx(dt_design * flow_fraction ** 1.5, rel=1e-9)
+
+
+def test_en16798_fan_explicit_product_data_matches_recirc_equations():
+    flow_fraction = 0.4
+    design_pressure_pa = 500.0
+    eta_nom = 0.72
+    q_ref_m3_h = 900.0
+    eta_ref = 0.68
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.0,
+        heating_coil_max_power_w=0.0,
+        supply_fan_specific_power_w_per_m3_s=0.0,
+        supply_fan_design_pressure_pa=design_pressure_pa,
+        supply_fan_nominal_efficiency=eta_nom,
+        supply_fan_reference_flow_m3_h=q_ref_m3_h,
+        supply_fan_reference_efficiency=eta_ref,
+        supply_fan_heat_fraction_to_air=1.0,
+        fan_performance_model="en16798_5_1",
+    )
+    out = calculate_sensible_ahu_step(cfg, _inp(flow_fraction=flow_fraction))
+
+    q_actual_m3_h = _Q_M3_H * flow_fraction
+    q_actual_m3_s = q_actual_m3_h / 3600.0
+    pressure_pa = design_pressure_pa * flow_fraction ** 2
+    efficiency = eta_nom * (eta_ref / eta_nom) * math.sqrt(
+        q_actual_m3_h / q_ref_m3_h
+    )
+    expected_power_w = q_actual_m3_s * pressure_pa / efficiency
+    expected_dt_k = pressure_pa / (_RHO_CP_J_M3_K * efficiency)
+
+    assert out.fan_electric_power_w == pytest.approx(expected_power_w, rel=1e-9)
+    assert out.actual_supply_temperature_c - (-9.7) == pytest.approx(
+        expected_dt_k,
+        rel=1e-9,
+    )
+
+
+def test_constant_sfp_mode_remains_available():
+    flow_fraction = 0.25
+    sfp = 500.0
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.0,
+        heating_coil_max_power_w=0.0,
+        supply_fan_specific_power_w_per_m3_s=sfp,
+        supply_fan_heat_fraction_to_air=1.0,
+        fan_performance_model="constant_sfp",
+    )
+    out_design = calculate_sensible_ahu_step(cfg, _inp())
+    out_part = calculate_sensible_ahu_step(
+        cfg,
+        _inp(flow_fraction=flow_fraction),
+    )
+
+    assert out_part.fan_electric_power_w == pytest.approx(
+        out_design.fan_electric_power_w * flow_fraction,
+        rel=1e-9,
+    )
+    assert out_part.actual_supply_temperature_c == pytest.approx(
+        out_design.actual_supply_temperature_c,
+        abs=1e-9,
+    )
+
+
+def test_operation_fraction_averages_power_without_changing_fan_temperature_rise():
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.0,
+        heating_coil_max_power_w=0.0,
+        supply_fan_specific_power_w_per_m3_s=500.0,
+        supply_fan_heat_fraction_to_air=1.0,
+    )
+    out_full = calculate_sensible_ahu_step(cfg, _inp(operation_fraction=1.0))
+    out_half_time = calculate_sensible_ahu_step(
+        cfg,
+        _inp(operation_fraction=0.5),
+    )
+
+    assert out_half_time.fan_electric_power_w == pytest.approx(
+        0.5 * out_full.fan_electric_power_w,
+        rel=1e-9,
+    )
+    assert out_half_time.actual_supply_temperature_c == pytest.approx(
+        out_full.actual_supply_temperature_c,
+        abs=1e-9,
+    )
+
+
+def test_extract_fan_zero_heat_fraction_supported_in_en16798_mode_at_part_load():
+    cfg_with_fan = _cfg(
+        extract_fan_specific_power_w_per_m3_s=500.0,
+        extract_fan_heat_fraction_to_air=0.0,
+        fan_performance_model="en16798_5_1",
+    )
+    cfg_without_fan = _cfg(extract_fan_specific_power_w_per_m3_s=0.0)
+    inp = _inp(flow_fraction=0.25)
+
+    out_with_fan = calculate_sensible_ahu_step(cfg_with_fan, inp)
+    out_without_fan = calculate_sensible_ahu_step(cfg_without_fan, inp)
+
+    assert out_with_fan.fan_electric_power_w > 0.0
+    assert out_with_fan.heat_recovery_power_w == pytest.approx(
+        out_without_fan.heat_recovery_power_w,
+        rel=1e-9,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Scheduled supply-temperature control in AHU step
 # ---------------------------------------------------------------------------
@@ -1094,6 +1240,9 @@ def test_from_dict_defaults():
     assert cfg.extract_fan_specific_power_w_per_m3_s == pytest.approx(0.0)
     assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(1.0)
     assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(1.0)
+    assert cfg.fan_performance_model is FanPerformanceModel.EN16798_5_1
+    assert cfg.supply_fan_nominal_efficiency == pytest.approx(0.72)
+    assert cfg.extract_fan_nominal_efficiency == pytest.approx(0.78)
 
 
 def test_from_dict_explicit_optional_fields():
@@ -1106,6 +1255,15 @@ def test_from_dict_explicit_optional_fields():
         extract_fan_specific_power_w_per_m3_s=150.0,
         supply_fan_heat_fraction_to_air=0.9,
         extract_fan_heat_fraction_to_air=0.8,
+        fan_performance_model="constant_sfp",
+        supply_fan_design_pressure_pa=450.0,
+        extract_fan_design_pressure_pa=350.0,
+        supply_fan_nominal_efficiency=0.70,
+        extract_fan_nominal_efficiency=0.75,
+        supply_fan_reference_flow_m3_h=1000.0,
+        extract_fan_reference_flow_m3_h=900.0,
+        supply_fan_reference_efficiency=0.68,
+        extract_fan_reference_efficiency=0.73,
     ))
     assert cfg.heat_recovery_control is HeatRecoveryControl.ALWAYS_ON
     assert cfg.frost_control is FrostControlMode.NONE
@@ -1115,6 +1273,15 @@ def test_from_dict_explicit_optional_fields():
     assert cfg.extract_fan_specific_power_w_per_m3_s == pytest.approx(150.0)
     assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(0.9)
     assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(0.8)
+    assert cfg.fan_performance_model is FanPerformanceModel.CONSTANT_SFP
+    assert cfg.supply_fan_design_pressure_pa == pytest.approx(450.0)
+    assert cfg.extract_fan_design_pressure_pa == pytest.approx(350.0)
+    assert cfg.supply_fan_nominal_efficiency == pytest.approx(0.70)
+    assert cfg.extract_fan_nominal_efficiency == pytest.approx(0.75)
+    assert cfg.supply_fan_reference_flow_m3_h == pytest.approx(1000.0)
+    assert cfg.extract_fan_reference_flow_m3_h == pytest.approx(900.0)
+    assert cfg.supply_fan_reference_efficiency == pytest.approx(0.68)
+    assert cfg.extract_fan_reference_efficiency == pytest.approx(0.73)
 
 
 def test_from_dict_missing_setpoint_raises():

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -5,9 +5,16 @@ import math
 import pytest
 
 from pybuildingenergy.source.ventilation_16798_5_1 import (
+    AHUStepInputs,
+    AHUStepOutputs,
     CompensationPoint,
+    FrostControlMode,
+    HeatRecoveryControl,
+    SensibleAHUConfig,
     SupplyTemperatureControl,
     SupplyTemperatureControlMode,
+    _RHO_CP_J_M3_K,
+    calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
 )
 
@@ -15,6 +22,10 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
 def _point(reference_c, supply_c):
     return CompensationPoint(reference_c, supply_c)
 
+
+# ---------------------------------------------------------------------------
+# Supply-temperature controller tests (existing)
+# ---------------------------------------------------------------------------
 
 def test_fixed_supply_temperature_control():
     control = SupplyTemperatureControl(
@@ -191,4 +202,572 @@ def test_control_accepts_string_mode_and_freezes_sorted_points():
     assert tuple(point.reference_temperature_c for point in control.points) == (
         21.0,
         23.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AHU model test helpers
+# ---------------------------------------------------------------------------
+
+_Q_M3_H = 1350.0  # nominal flow rate used in most tests
+_Q_M3_S = _Q_M3_H / 3600.0
+
+_FIXED_18 = SupplyTemperatureControl(
+    mode=SupplyTemperatureControlMode.FIXED,
+    setpoint_c=18.0,
+)
+
+
+def _cfg(**kw) -> SensibleAHUConfig:
+    defaults = dict(
+        sensible_heat_recovery_efficiency=0.75,
+        supply_temperature_control=_FIXED_18,
+        heat_recovery_control="modulating_bypass",
+        frost_control="bypass",
+        heating_coil_max_power_w=None,
+        cooling_coil_enabled=False,
+        supply_fan_specific_power_w_per_m3_s=0.0,
+        extract_fan_specific_power_w_per_m3_s=0.0,
+        supply_fan_heat_fraction_to_air=1.0,
+        extract_fan_heat_fraction_to_air=0.0,
+    )
+    defaults.update(kw)
+    return SensibleAHUConfig(**defaults)
+
+
+def _inp(**kw) -> AHUStepInputs:
+    defaults = dict(
+        outdoor_temperature_c=-9.7,
+        extract_temperature_c=21.0,
+        required_supply_flow_m3_h=_Q_M3_H,
+        required_extract_flow_m3_h=_Q_M3_H,
+        operation_fraction=1.0,
+        timestep_hours=1.0,
+    )
+    defaults.update(kw)
+    return AHUStepInputs(**defaults)
+
+
+def _rho_cp_q(q_m3_s: float = _Q_M3_S) -> float:
+    return _RHO_CP_J_M3_K * q_m3_s
+
+
+# ---------------------------------------------------------------------------
+# SensibleAHUConfig validation
+# ---------------------------------------------------------------------------
+
+def test_config_accepts_string_enum_values():
+    cfg = _cfg(heat_recovery_control="always_on", frost_control="none")
+    assert cfg.heat_recovery_control is HeatRecoveryControl.ALWAYS_ON
+    assert cfg.frost_control is FrostControlMode.NONE
+
+
+def test_config_rejects_unknown_heat_recovery_control():
+    with pytest.raises(ValueError, match="heat_recovery_control"):
+        _cfg(heat_recovery_control="turbo")
+
+
+def test_config_rejects_unknown_frost_control():
+    with pytest.raises(ValueError, match="frost_control"):
+        _cfg(frost_control="preheat")
+
+
+def test_config_rejects_efficiency_above_one():
+    with pytest.raises(ValueError, match="sensible_heat_recovery_efficiency"):
+        _cfg(sensible_heat_recovery_efficiency=1.01)
+
+
+def test_config_rejects_negative_efficiency():
+    with pytest.raises(ValueError, match="sensible_heat_recovery_efficiency"):
+        _cfg(sensible_heat_recovery_efficiency=-0.1)
+
+
+def test_config_rejects_non_finite_efficiency():
+    with pytest.raises(ValueError):
+        _cfg(sensible_heat_recovery_efficiency=math.nan)
+
+
+def test_config_rejects_negative_fan_power():
+    with pytest.raises(ValueError, match="supply_fan_specific_power"):
+        _cfg(supply_fan_specific_power_w_per_m3_s=-1.0)
+
+
+def test_config_rejects_fan_fraction_above_one():
+    with pytest.raises(ValueError, match="supply_fan_heat_fraction"):
+        _cfg(supply_fan_heat_fraction_to_air=1.1)
+
+
+def test_config_rejects_zero_heating_coil_max():
+    with pytest.raises(ValueError, match="heating_coil_max_power_w"):
+        _cfg(heating_coil_max_power_w=0.0)
+
+
+def test_config_rejects_negative_heating_coil_max():
+    with pytest.raises(ValueError, match="heating_coil_max_power_w"):
+        _cfg(heating_coil_max_power_w=-100.0)
+
+
+def test_config_none_heating_coil_max_accepted():
+    cfg = _cfg(heating_coil_max_power_w=None)
+    assert cfg.heating_coil_max_power_w is None
+
+
+def test_config_rejects_wrong_supply_temperature_control_type():
+    with pytest.raises(TypeError, match="supply_temperature_control"):
+        _cfg(supply_temperature_control="fixed:18")
+
+
+# ---------------------------------------------------------------------------
+# AHUStepInputs validation
+# ---------------------------------------------------------------------------
+
+def test_inputs_rejects_negative_flow():
+    with pytest.raises(ValueError, match="required_supply_flow_m3_h"):
+        _inp(required_supply_flow_m3_h=-100.0)
+
+
+def test_inputs_rejects_operation_fraction_above_one():
+    with pytest.raises(ValueError, match="operation_fraction"):
+        _inp(operation_fraction=1.5)
+
+
+def test_inputs_rejects_negative_operation_fraction():
+    with pytest.raises(ValueError, match="operation_fraction"):
+        _inp(operation_fraction=-0.1)
+
+
+def test_inputs_rejects_zero_timestep():
+    with pytest.raises(ValueError, match="timestep_hours"):
+        _inp(timestep_hours=0.0)
+
+
+def test_inputs_rejects_non_finite_outdoor_temperature():
+    with pytest.raises(ValueError, match="outdoor_temperature_c"):
+        _inp(outdoor_temperature_c=math.nan)
+
+
+def test_inputs_rejects_non_finite_scheduled_setpoint():
+    with pytest.raises(ValueError, match="scheduled_setpoint_c"):
+        _inp(scheduled_setpoint_c=math.inf)
+
+
+def test_inputs_zero_extract_flow_accepted():
+    inp = _inp(required_extract_flow_m3_h=0.0)
+    assert inp.required_extract_flow_m3_h == 0.0
+
+
+# ---------------------------------------------------------------------------
+# calculate_sensible_ahu_step: type guards
+# ---------------------------------------------------------------------------
+
+def test_rejects_non_config():
+    with pytest.raises(TypeError, match="config"):
+        calculate_sensible_ahu_step("not a config", _inp())
+
+
+def test_rejects_non_inputs():
+    with pytest.raises(TypeError, match="inputs"):
+        calculate_sensible_ahu_step(_cfg(), "not inputs")
+
+
+# ---------------------------------------------------------------------------
+# Zero operation
+# ---------------------------------------------------------------------------
+
+def test_zero_operation_produces_zero_flow_and_energy():
+    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
+    assert out.actual_supply_flow_m3_h == 0.0
+    assert out.actual_extract_flow_m3_h == 0.0
+    assert out.fan_electric_power_w == 0.0
+    assert out.heat_recovery_power_w == 0.0
+    assert out.required_heating_coil_power_w == 0.0
+    assert out.actual_heating_coil_power_w == 0.0
+    assert out.bypass_fraction == 0.0
+    assert not out.frost_control_active
+
+
+def test_zero_operation_still_resolves_requested_setpoint():
+    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.0))
+    assert out.requested_supply_temperature_c == pytest.approx(18.0)
+
+
+def test_zero_required_flow_equivalent_to_zero_operation():
+    out = calculate_sensible_ahu_step(
+        _cfg(), _inp(required_supply_flow_m3_h=0.0, required_extract_flow_m3_h=0.0)
+    )
+    assert out.actual_supply_flow_m3_h == 0.0
+    assert out.fan_electric_power_w == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Actual flows scale with operation_fraction
+# ---------------------------------------------------------------------------
+
+def test_actual_flows_scale_with_operation_fraction():
+    out = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.5))
+    assert out.actual_supply_flow_m3_h == pytest.approx(0.5 * _Q_M3_H)
+    assert out.actual_extract_flow_m3_h == pytest.approx(0.5 * _Q_M3_H)
+
+
+# ---------------------------------------------------------------------------
+# Heat recovery
+# ---------------------------------------------------------------------------
+
+def test_zero_hr_efficiency_no_heat_recovery():
+    cfg = _cfg(sensible_heat_recovery_efficiency=0.0)
+    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=-9.7))
+    assert out.heat_recovery_power_w == pytest.approx(0.0, abs=1e-9)
+    # All heating must come from the coil
+    expected_coil = _rho_cp_q() * (18.0 - (-9.7))
+    assert out.required_heating_coil_power_w == pytest.approx(expected_coil, rel=1e-6)
+    assert out.actual_heating_coil_power_w == pytest.approx(expected_coil, rel=1e-6)
+
+
+def test_nominal_hr_efficiency_warms_supply():
+    # T_outdoor=-9.7, T_extract=21, eta=0.75
+    # T_hr = -9.7 + 0.75*(21 - (-9.7)) = -9.7 + 23.025 = 13.325°C
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+
+    t_hr = -9.7 + 0.75 * (21.0 - (-9.7))
+    expected_hr = _rho_cp_q() * (t_hr - (-9.7))
+    assert out.heat_recovery_power_w == pytest.approx(expected_hr, rel=1e-6)
+
+    expected_coil = _rho_cp_q() * (18.0 - t_hr)
+    assert out.required_heating_coil_power_w == pytest.approx(expected_coil, rel=1e-6)
+    assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+
+
+def test_sensible_energy_balance_closes():
+    """Q_hr + Q_coil = rho*cp*q*(T_supply - T_outdoor)"""
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    total_supply = _rho_cp_q() * (
+        out.actual_supply_temperature_c - (-9.7)
+    )
+    assert total_supply == pytest.approx(
+        out.heat_recovery_power_w + out.actual_heating_coil_power_w, rel=1e-6
+    )
+
+
+# ---------------------------------------------------------------------------
+# Modulating bypass
+# ---------------------------------------------------------------------------
+
+def test_bypass_activates_when_hr_overshoots_setpoint_in_heating_mode():
+    # T_outdoor=10, T_extract=22, eta=0.75 → T_hr=10+0.75*12=19°C > setpoint=16°C
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=16.0)
+    cfg = _cfg(sensible_heat_recovery_efficiency=0.75, supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0))
+
+    t_hr_full = 10.0 + 0.75 * 12.0  # 19.0°C
+    expected_bp = (t_hr_full - 16.0) / (t_hr_full - 10.0)
+    assert out.bypass_fraction == pytest.approx(expected_bp, rel=1e-6)
+    assert out.actual_supply_temperature_c == pytest.approx(16.0, abs=1e-6)
+    assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+def test_bypass_activates_in_economizer_mode_to_avoid_overcooling():
+    # T_outdoor=25, T_extract=21, eta=0.75 → T_hr=25+0.75*(21-25)=22°C < setpoint=23°C < 25°C
+    # HR overcools; bypass warms supply by mixing in outdoor air
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=23.0)
+    cfg = _cfg(sensible_heat_recovery_efficiency=0.75, supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=25.0, extract_temperature_c=21.0)
+    )
+
+    t_hr_full = 25.0 + 0.75 * (21.0 - 25.0)  # 22.0°C
+    expected_bp = (t_hr_full - 23.0) / (t_hr_full - 25.0)  # (22-23)/(22-25) = 1/3
+    assert out.bypass_fraction == pytest.approx(expected_bp, rel=1e-6)
+    assert out.actual_supply_temperature_c == pytest.approx(23.0, abs=1e-6)
+
+
+def test_no_bypass_when_hr_undershoots_setpoint():
+    # HR cannot reach setpoint (T_hr < setpoint); heating coil required, no bypass
+    out = calculate_sensible_ahu_step(_cfg(), _inp(outdoor_temperature_c=-9.7))
+    t_hr = -9.7 + 0.75 * (21.0 - (-9.7))  # 13.325°C < 18°C setpoint
+    assert out.bypass_fraction == pytest.approx(0.0, abs=1e-9)
+    assert out.heat_recovery_power_w > 0.0
+    assert out.required_heating_coil_power_w > 0.0
+
+
+def test_bypass_zero_when_hr_output_equals_setpoint():
+    # T_outdoor=10, T_extract=22, eta=0.75 → T_hr=19°C; setpoint=19°C → no bypass
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=19.0)
+    cfg = _cfg(sensible_heat_recovery_efficiency=0.75, supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0)
+    )
+    assert out.bypass_fraction == pytest.approx(0.0, abs=1e-9)
+
+
+def test_always_on_hr_does_not_bypass_even_when_setpoint_below_hr_output():
+    # HR overshoots setpoint but always_on → no bypass
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=16.0)
+    cfg = _cfg(
+        heat_recovery_control="always_on",
+        supply_temperature_control=ctrl,
+        sensible_heat_recovery_efficiency=0.75,
+    )
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0)
+    )
+    assert out.bypass_fraction == pytest.approx(0.0, abs=1e-9)
+    t_hr_full = 10.0 + 0.75 * 12.0  # 19.0°C
+    assert out.actual_supply_temperature_c == pytest.approx(t_hr_full, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Frost control
+# ---------------------------------------------------------------------------
+
+def test_frost_control_activates_when_exhaust_would_freeze():
+    # T_extract=21, T_outdoor=-15, eta=0.75
+    # T_EHA_nominal = 21 - 0.75*(21-(-15)) = 21 - 27 = -6°C < limit -5°C → frost
+    out = calculate_sensible_ahu_step(
+        _cfg(frost_exhaust_limit_c=-5.0),
+        _inp(outdoor_temperature_c=-15.0, extract_temperature_c=21.0),
+    )
+    assert out.frost_control_active
+
+
+def test_frost_control_reduces_hr_efficiency_to_keep_exhaust_at_limit():
+    t_ext, t_oda = 21.0, -15.0
+    dT = t_ext - t_oda  # 36 K
+    frost_limit = -5.0
+    eta_frost = (t_ext - frost_limit) / dT  # 26/36
+
+    out = calculate_sensible_ahu_step(
+        _cfg(sensible_heat_recovery_efficiency=0.75, frost_exhaust_limit_c=frost_limit),
+        _inp(outdoor_temperature_c=t_oda, extract_temperature_c=t_ext),
+    )
+
+    t_hr_expected = t_oda + eta_frost * dT
+    expected_hr_power = _rho_cp_q() * (t_hr_expected - t_oda)
+    assert out.heat_recovery_power_w == pytest.approx(expected_hr_power, rel=1e-5)
+
+
+def test_frost_control_not_active_when_exhaust_above_limit():
+    # T_extract=21, T_outdoor=-5, eta=0.75
+    # T_EHA = 21 - 0.75*(21-(-5)) = 21 - 19.5 = 1.5°C > -5°C → no frost
+    out = calculate_sensible_ahu_step(
+        _cfg(frost_exhaust_limit_c=-5.0),
+        _inp(outdoor_temperature_c=-5.0, extract_temperature_c=21.0),
+    )
+    assert not out.frost_control_active
+
+
+def test_frost_mode_none_never_activates():
+    cfg = _cfg(frost_control="none", sensible_heat_recovery_efficiency=0.9)
+    # Very cold outdoor, would normally trigger frost
+    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=-20.0))
+    assert not out.frost_control_active
+
+
+# ---------------------------------------------------------------------------
+# Heating coil
+# ---------------------------------------------------------------------------
+
+def test_unlimited_coil_always_reaches_setpoint():
+    cfg = _cfg(heating_coil_max_power_w=None)
+    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=-20.0))
+    assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+    assert out.actual_heating_coil_power_w == pytest.approx(
+        out.required_heating_coil_power_w, rel=1e-9
+    )
+
+
+def test_capacity_limited_coil_misses_setpoint():
+    # Limit to 100 W — far below what is needed for cold outdoor
+    cfg = _cfg(heating_coil_max_power_w=100.0)
+    out = calculate_sensible_ahu_step(cfg, _inp(outdoor_temperature_c=-9.7))
+    assert out.actual_heating_coil_power_w == pytest.approx(100.0, rel=1e-9)
+    assert out.actual_heating_coil_power_w < out.required_heating_coil_power_w
+    assert out.actual_supply_temperature_c < 18.0
+
+
+def test_no_heating_needed_when_hr_meets_setpoint_exactly():
+    # T_outdoor=10, T_extract=22, eta=0.5 → T_hr=10+0.5*12=16°C; setpoint=16°C
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=16.0)
+    cfg = _cfg(sensible_heat_recovery_efficiency=0.5, supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=10.0, extract_temperature_c=22.0)
+    )
+    assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    assert out.actual_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Cooling disabled — unattainable cold setpoints
+# ---------------------------------------------------------------------------
+
+def test_disabled_cooling_leaves_supply_at_hr_output_when_setpoint_below_outdoor():
+    # T_outdoor=5, T_extract=22, setpoint=2°C < T_outdoor — unattainable without cooling
+    # T_hr = 5 + 0.75*17 = 17.75°C; setpoint (2°C) is below T_outdoor (5°C)
+    # Neither bypass nor coil can cool; actual supply stays at T_hr
+    ctrl = SupplyTemperatureControl(mode="fixed", setpoint_c=2.0)
+    cfg = _cfg(
+        sensible_heat_recovery_efficiency=0.75,
+        supply_temperature_control=ctrl,
+        cooling_coil_enabled=False,
+    )
+    out = calculate_sensible_ahu_step(
+        cfg, _inp(outdoor_temperature_c=5.0, extract_temperature_c=22.0)
+    )
+    t_hr = 5.0 + 0.75 * (22.0 - 5.0)
+    assert out.actual_supply_temperature_c == pytest.approx(t_hr, rel=1e-6)
+    assert out.required_heating_coil_power_w == pytest.approx(0.0, abs=1e-9)
+    assert out.bypass_fraction == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Fan heat and electricity
+# ---------------------------------------------------------------------------
+
+def test_extract_fan_heat_warms_extract_before_hr():
+    """Extract fan heat increases HR recovery by warming the extract air."""
+    sfp = 500.0  # W/(m³/s)
+    p_eta = _Q_M3_S * sfp
+    dt_eta = p_eta / (_RHO_CP_J_M3_K * _Q_M3_S)
+
+    cfg_with = _cfg(
+        extract_fan_specific_power_w_per_m3_s=sfp,
+        extract_fan_heat_fraction_to_air=1.0,
+        sensible_heat_recovery_efficiency=0.75,
+    )
+    cfg_without = _cfg(extract_fan_specific_power_w_per_m3_s=0.0)
+
+    out_with = calculate_sensible_ahu_step(cfg_with, _inp())
+    out_without = calculate_sensible_ahu_step(cfg_without, _inp())
+
+    assert out_with.heat_recovery_power_w > out_without.heat_recovery_power_w
+
+    # Precise check: T_ext_at_hr increases by dt_eta
+    t_ext_at_hr = 21.0 + dt_eta
+    dT = t_ext_at_hr - (-9.7)
+    t_hr = -9.7 + 0.75 * dT
+    expected_hr = _rho_cp_q() * (t_hr - (-9.7))
+    assert out_with.heat_recovery_power_w == pytest.approx(expected_hr, rel=1e-5)
+
+
+def test_extract_fan_heat_zero_fraction_does_not_affect_hr():
+    """Extract fan heat fraction=0 means no heat added to extract airstream."""
+    sfp = 500.0
+    cfg_zero_frac = _cfg(
+        extract_fan_specific_power_w_per_m3_s=sfp,
+        extract_fan_heat_fraction_to_air=0.0,
+    )
+    cfg_no_fan = _cfg(extract_fan_specific_power_w_per_m3_s=0.0)
+
+    out_zero_frac = calculate_sensible_ahu_step(cfg_zero_frac, _inp())
+    out_no_fan = calculate_sensible_ahu_step(cfg_no_fan, _inp())
+
+    # Same HR power; electricity differs
+    assert out_zero_frac.heat_recovery_power_w == pytest.approx(
+        out_no_fan.heat_recovery_power_w, rel=1e-9
+    )
+    assert out_zero_frac.fan_electric_power_w > out_no_fan.fan_electric_power_w
+
+
+def test_supply_fan_heat_adds_to_supply_after_coil():
+    """Supply fan heat raises actual supply above setpoint."""
+    sfp = 500.0
+    p_sup = _Q_M3_S * sfp
+    dt_sup = p_sup / (_RHO_CP_J_M3_K * _Q_M3_S)
+
+    cfg = _cfg(
+        supply_fan_specific_power_w_per_m3_s=sfp,
+        supply_fan_heat_fraction_to_air=1.0,
+    )
+    out = calculate_sensible_ahu_step(cfg, _inp())
+
+    # Setpoint is 18°C; supply fan adds dt_sup on top
+    assert out.actual_supply_temperature_c == pytest.approx(18.0 + dt_sup, rel=1e-5)
+
+
+def test_supply_fan_zero_heat_fraction_does_not_raise_supply():
+    sfp = 500.0
+    cfg = _cfg(
+        supply_fan_specific_power_w_per_m3_s=sfp,
+        supply_fan_heat_fraction_to_air=0.0,
+    )
+    out = calculate_sensible_ahu_step(cfg, _inp())
+    assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-6)
+    assert out.fan_electric_power_w == pytest.approx(_Q_M3_S * sfp, rel=1e-9)
+
+
+def test_fan_electricity_is_separate_from_thermal_heating():
+    sfp = 300.0
+    cfg = _cfg(
+        supply_fan_specific_power_w_per_m3_s=sfp,
+        extract_fan_specific_power_w_per_m3_s=sfp,
+        supply_fan_heat_fraction_to_air=0.0,
+        extract_fan_heat_fraction_to_air=0.0,
+    )
+    out = calculate_sensible_ahu_step(cfg, _inp())
+
+    # Fan electricity = both fans, no heat to airstreams
+    expected_electric = 2.0 * _Q_M3_S * sfp
+    assert out.fan_electric_power_w == pytest.approx(expected_electric, rel=1e-9)
+
+    # Coil power is same as without fans (no thermal interaction)
+    out_no_fan = calculate_sensible_ahu_step(_cfg(), _inp())
+    assert out.required_heating_coil_power_w == pytest.approx(
+        out_no_fan.required_heating_coil_power_w, rel=1e-6
+    )
+
+
+def test_fan_electricity_zero_when_no_fans_configured():
+    out = calculate_sensible_ahu_step(_cfg(), _inp())
+    assert out.fan_electric_power_w == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Scheduled supply-temperature control in AHU step
+# ---------------------------------------------------------------------------
+
+def test_scheduled_control_uses_scheduled_setpoint_c_from_inputs():
+    ctrl = SupplyTemperatureControl(mode="scheduled")
+    cfg = _cfg(supply_temperature_control=ctrl)
+    out = calculate_sensible_ahu_step(cfg, _inp(scheduled_setpoint_c=20.0))
+    assert out.requested_supply_temperature_c == pytest.approx(20.0)
+    assert out.actual_supply_temperature_c == pytest.approx(20.0, abs=1e-6)
+
+
+def test_scheduled_control_raises_without_setpoint():
+    ctrl = SupplyTemperatureControl(mode="scheduled")
+    cfg = _cfg(supply_temperature_control=ctrl)
+    with pytest.raises(ValueError, match="requires scheduled_setpoint_c"):
+        calculate_sensible_ahu_step(cfg, _inp())
+
+
+# ---------------------------------------------------------------------------
+# Requested setpoint always reported
+# ---------------------------------------------------------------------------
+
+def test_requested_setpoint_matches_controller_output():
+    ctrl = SupplyTemperatureControl(
+        mode="extract_compensated",
+        points=(_point(21.0, 19.0), _point(23.0, 17.0)),
+    )
+    cfg = _cfg(supply_temperature_control=ctrl)
+    inp = _inp(extract_temperature_c=22.0)
+    out = calculate_sensible_ahu_step(cfg, inp)
+    assert out.requested_supply_temperature_c == pytest.approx(18.0)  # midpoint
+
+
+# ---------------------------------------------------------------------------
+# Operation fraction partial load
+# ---------------------------------------------------------------------------
+
+def test_partial_load_scales_all_power_outputs():
+    out_full = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=1.0))
+    out_half = calculate_sensible_ahu_step(_cfg(), _inp(operation_fraction=0.5))
+
+    assert out_half.actual_supply_flow_m3_h == pytest.approx(
+        0.5 * out_full.actual_supply_flow_m3_h
+    )
+    assert out_half.heat_recovery_power_w == pytest.approx(
+        0.5 * out_full.heat_recovery_power_w, rel=1e-6
+    )
+    assert out_half.required_heating_coil_power_w == pytest.approx(
+        0.5 * out_full.required_heating_coil_power_w, rel=1e-6
     )

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -17,6 +17,7 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     ahu_outputs_to_ventilation_stream,
     calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
+    sensible_ahu_config_from_dict,
 )
 from pybuildingenergy.source.ventilation import VentilationBoundary, VentilationStream
 
@@ -1060,3 +1061,80 @@ def test_integration_s_ve_sign_convention_positive_is_heat_to_zone():
     bnd_hot = VentilationBoundary([ahu_hot])
     assert out_hot.actual_supply_temperature_c > t_zone
     assert bnd_hot.sensible_heat_flow_w(t_zone) < 0.0
+
+
+# ---------------------------------------------------------------------------
+# sensible_ahu_config_from_dict — component-dict factory
+# ---------------------------------------------------------------------------
+
+def _minimal_ahu_dict(**overrides):
+    d = {
+        "sensible_heat_recovery_efficiency": 0.784,
+        "supply_temperature_setpoint_c": 18.0,
+    }
+    d.update(overrides)
+    return d
+
+
+def test_from_dict_required_fields():
+    cfg = sensible_ahu_config_from_dict(_minimal_ahu_dict())
+    assert cfg.sensible_heat_recovery_efficiency == pytest.approx(0.784)
+    assert cfg.supply_temperature_control.setpoint_c == pytest.approx(18.0)
+
+
+def test_from_dict_defaults():
+    cfg = sensible_ahu_config_from_dict(_minimal_ahu_dict())
+    assert cfg.heat_recovery_control is HeatRecoveryControl.MODULATING_BYPASS
+    assert cfg.frost_control is FrostControlMode.EXHAUST_LIMIT
+    assert cfg.frost_exhaust_limit_c == pytest.approx(-5.0)
+    assert cfg.heating_coil_max_power_w is None
+    assert cfg.cooling_coil_enabled is False
+    assert cfg.supply_fan_specific_power_w_per_m3_s == pytest.approx(0.0)
+    assert cfg.extract_fan_specific_power_w_per_m3_s == pytest.approx(0.0)
+    assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(1.0)
+    assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(1.0)
+
+
+def test_from_dict_explicit_optional_fields():
+    cfg = sensible_ahu_config_from_dict(_minimal_ahu_dict(
+        heat_recovery_control="always_on",
+        frost_control="none",
+        frost_exhaust_limit_c=-3.0,
+        heating_coil_max_power_w=5000.0,
+        supply_fan_specific_power_w_per_m3_s=200.0,
+        extract_fan_specific_power_w_per_m3_s=150.0,
+        supply_fan_heat_fraction_to_air=0.9,
+        extract_fan_heat_fraction_to_air=0.8,
+    ))
+    assert cfg.heat_recovery_control is HeatRecoveryControl.ALWAYS_ON
+    assert cfg.frost_control is FrostControlMode.NONE
+    assert cfg.frost_exhaust_limit_c == pytest.approx(-3.0)
+    assert cfg.heating_coil_max_power_w == pytest.approx(5000.0)
+    assert cfg.supply_fan_specific_power_w_per_m3_s == pytest.approx(200.0)
+    assert cfg.extract_fan_specific_power_w_per_m3_s == pytest.approx(150.0)
+    assert cfg.supply_fan_heat_fraction_to_air == pytest.approx(0.9)
+    assert cfg.extract_fan_heat_fraction_to_air == pytest.approx(0.8)
+
+
+def test_from_dict_missing_setpoint_raises():
+    with pytest.raises(KeyError, match="supply_temperature_setpoint_c"):
+        sensible_ahu_config_from_dict({"sensible_heat_recovery_efficiency": 0.8})
+
+
+def test_from_dict_missing_efficiency_raises():
+    with pytest.raises(KeyError):
+        sensible_ahu_config_from_dict({"supply_temperature_setpoint_c": 18.0})
+
+
+def test_from_dict_produces_runnable_config():
+    cfg = sensible_ahu_config_from_dict(_minimal_ahu_dict())
+    inp = AHUStepInputs(
+        outdoor_temperature_c=-5.0,
+        extract_temperature_c=21.0,
+        required_supply_flow_m3_h=3600.0,
+        required_extract_flow_m3_h=3600.0,
+        operation_fraction=1.0,
+        timestep_hours=1.0,
+    )
+    out = calculate_sensible_ahu_step(cfg, inp)
+    assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)

--- a/tests/test_ventilation_16798_5_1.py
+++ b/tests/test_ventilation_16798_5_1.py
@@ -14,6 +14,7 @@ from pybuildingenergy.source.ventilation_16798_5_1 import (
     SupplyTemperatureControl,
     SupplyTemperatureControlMode,
     _RHO_CP_J_M3_K,
+    _opt_float,
     ahu_outputs_to_ventilation_stream,
     calculate_sensible_ahu_step,
     resolve_supply_temperature_setpoint,
@@ -1138,3 +1139,63 @@ def test_from_dict_produces_runnable_config():
     )
     out = calculate_sensible_ahu_step(cfg, inp)
     assert out.actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+
+
+def test_from_dict_outdoor_compensated_mode():
+    """outdoor_compensated mode with two-point curve."""
+    # Points: T_oda=-20 → T_sup=19, T_oda=+15 → T_sup=17 (ZEBlab-like curve)
+    cfg = sensible_ahu_config_from_dict({
+        "sensible_heat_recovery_efficiency": 0.784,
+        "supply_temperature_mode": "outdoor_compensated",
+        "supply_temperature_points": [[-20, 19], [15, 17]],
+    })
+    assert cfg.supply_temperature_control.mode is SupplyTemperatureControlMode.OUTDOOR_COMPENSATED
+    assert len(cfg.supply_temperature_control.points) == 2
+
+
+def test_from_dict_outdoor_compensated_delivers_interpolated_setpoint():
+    """At T_oda=0, interpolated setpoint = 17 + (15-0)/(15-(-20)) * (19-17) = 17 + 15/35*2 ≈ 17.857."""
+    cfg = sensible_ahu_config_from_dict({
+        "sensible_heat_recovery_efficiency": 0.784,
+        "supply_temperature_mode": "outdoor_compensated",
+        "supply_temperature_points": [[-20, 19], [15, 17]],
+    })
+    inp = AHUStepInputs(
+        outdoor_temperature_c=0.0,
+        extract_temperature_c=21.0,
+        required_supply_flow_m3_h=3600.0,
+        required_extract_flow_m3_h=3600.0,
+        operation_fraction=1.0,
+        timestep_hours=1.0,
+    )
+    out = calculate_sensible_ahu_step(cfg, inp)
+    expected_setpoint = 17.0 + (15.0 - 0.0) / (15.0 - (-20.0)) * (19.0 - 17.0)
+    assert out.requested_supply_temperature_c == pytest.approx(expected_setpoint, rel=1e-6)
+    # Actual supply reaches the setpoint (HR+coil can cover T_oda=0 → setpoint≈17.86)
+    assert out.actual_supply_temperature_c == pytest.approx(expected_setpoint, abs=0.1)
+
+
+def test_from_dict_outdoor_compensated_missing_points_raises():
+    with pytest.raises(KeyError, match="supply_temperature_points"):
+        sensible_ahu_config_from_dict({
+            "sensible_heat_recovery_efficiency": 0.784,
+            "supply_temperature_mode": "outdoor_compensated",
+        })
+
+
+def test_from_dict_unknown_mode_raises():
+    with pytest.raises(ValueError, match="Unsupported supply_temperature_mode"):
+        sensible_ahu_config_from_dict({
+            "sensible_heat_recovery_efficiency": 0.784,
+            "supply_temperature_mode": "magic",
+            "supply_temperature_setpoint_c": 18.0,
+        })
+
+
+def test_opt_float_returns_none_for_none():
+    assert _opt_float(None) is None
+
+
+def test_opt_float_converts_numeric():
+    assert _opt_float(17.5) == pytest.approx(17.5)
+    assert _opt_float("18") == pytest.approx(18.0)

--- a/tests/test_ventilation_boundary.py
+++ b/tests/test_ventilation_boundary.py
@@ -2045,6 +2045,7 @@ def _make_step_outputs(**overrides) -> AHUStepOutputs:
         required_heating_coil_power_w=500.0,
         actual_heating_coil_power_w=500.0,
         required_cooling_coil_power_w=0.0,
+        actual_cooling_coil_power_w=0.0,
         fan_electric_power_w=200.0,
         heat_recovery_power_w=3000.0,
         bypass_fraction=0.0,
@@ -2061,7 +2062,8 @@ class TestAhuCollToColumns:
         out = _make_step_outputs()
         cols = _ahu_coll_to_columns([{"ahu": out}])
         expected = {
-            "Q_ahu_coil_ahu", "Q_ahu_coil_req_ahu", "Q_ahu_cool_req_ahu",
+            "Q_ahu_coil_ahu", "Q_ahu_coil_req_ahu",
+            "Q_ahu_cool_ahu", "Q_ahu_cool_req_ahu",
             "Q_ahu_hr_ahu", "P_ahu_fan_ahu",
             "T_ahu_sup_ahu", "T_ahu_sup_req_ahu",
             "q_sup_m3h_ahu", "q_ext_m3h_ahu",

--- a/tests/test_ventilation_boundary.py
+++ b/tests/test_ventilation_boundary.py
@@ -1762,3 +1762,181 @@ class TestCausalSolverPath:
             )
         out = result[0] if isinstance(result, tuple) else result
         assert "H_ve" in out.columns, "Causal core must return H_ve when schedule kwarg is None"
+
+
+# ---------------------------------------------------------------------------
+# mechanical_supply component type (EN 16798-5-1 AHU step wired into boundary)
+# ---------------------------------------------------------------------------
+
+def _ahu_component(**overrides):
+    """Minimal mechanical_supply component dict."""
+    d = {
+        "name": "ahu",
+        "ventilation_type": "mechanical_supply",
+        "supply_flow_m3_h": 3600.0,
+        "sensible_heat_recovery_efficiency": 0.784,
+        "supply_temperature_setpoint_c": 18.0,
+    }
+    d.update(overrides)
+    return d
+
+
+def _ahu_building(components):
+    return {"building_parameters": {"ventilation": {"components": components}}}
+
+
+class TestMechanicalSupplyComponent:
+
+    def test_h_ve_equals_rho_cp_times_flow(self):
+        """H_ve = rho_cp * q_m3_s for a fully operating AHU."""
+        bdy = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+        )
+        rho_cp = 1.204 * 1006.0   # independent constant, not imported from module
+        expected_h = rho_cp * 3600.0 / 3600.0  # q = 1.0 m³/s
+        assert bdy.heat_transfer_coefficient_w_k == pytest.approx(expected_h, rel=1e-5)
+
+    def test_supply_temperature_reaches_setpoint(self):
+        """When HR + coil can cover the load, supply temperature equals the setpoint."""
+        bdy = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+        )
+        # equivalent_supply_temperature_c = S_ve / H_ve
+        assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+
+    def test_ahu_off_when_operation_fraction_zero(self):
+        """An AHU with operation_fraction=0 contributes zero H_ve and S_ve."""
+        bdy = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            component_multipliers={"ahu": 0.0},
+        )
+        assert bdy.heat_transfer_coefficient_w_k == pytest.approx(0.0)
+        assert bdy.source_term_w == pytest.approx(0.0)
+
+    def test_infiltration_independent_of_ahu_schedule(self):
+        """Infiltration (constant_ach, no profile) remains active when AHU is off."""
+        components = [
+            _ahu_component(),
+            {
+                "name": "inf",
+                "ventilation_type": "constant_ach",
+                "air_changes_per_hour": 0.5,
+            },
+        ]
+        bdy_on = resolve_ventilation_boundary(
+            _ahu_building(components),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            component_multipliers={"ahu": 1.0},
+            zone_volume_m3=5000.0,
+        )
+        bdy_off = resolve_ventilation_boundary(
+            _ahu_building(components),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            component_multipliers={"ahu": 0.0},
+            zone_volume_m3=5000.0,
+        )
+        rho_cp = 1.204 * 1006.0
+        h_inf = rho_cp * 0.5 * 5000.0 / 3600.0
+        # AHU off → only infiltration
+        assert bdy_off.heat_transfer_coefficient_w_k == pytest.approx(h_inf, rel=1e-4)
+        # AHU on → infiltration + AHU
+        assert bdy_on.heat_transfer_coefficient_w_k > h_inf
+
+    def test_extract_flow_defaults_to_supply_flow(self):
+        """Omitting extract_flow_m3_h defaults to supply_flow_m3_h (balanced)."""
+        bdy_explicit = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component(extract_flow_m3_h=3600.0)]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+        )
+        bdy_default = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+        )
+        assert bdy_explicit.heat_transfer_coefficient_w_k == pytest.approx(
+            bdy_default.heat_transfer_coefficient_w_k, rel=1e-9
+        )
+        assert bdy_explicit.source_term_w == pytest.approx(
+            bdy_default.source_term_w, rel=1e-9
+        )
+
+    def test_bypass_active_when_hr_would_overheat(self):
+        """When T_oda > T_set, bypass mixes to reach setpoint, reducing H_ve."""
+        # T_oda=12, T_ext=21, T_set=18 → bypass fraction > 0
+        # Effective temperature rise = 18 - 12 = 6 K (not 9 K from full HR)
+        bdy = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=12.0,
+            wind_speed_m_s=0.0,
+        )
+        rho_cp = 1.204 * 1006.0
+        # Still full flow, so H_ve unchanged; but S_ve = H_ve * T_sup = H_ve * 18
+        expected_h = rho_cp * 1.0
+        assert bdy.heat_transfer_coefficient_w_k == pytest.approx(expected_h, rel=1e-5)
+        assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+
+    def test_extract_temperature_affects_hr(self):
+        """Higher extract temperature → more HR power → higher supply temperature."""
+        # At T_oda=-10, T_ext=21 → T_hr = -10 + 0.784*31 = 14.304 → coil to 18
+        # At T_oda=-10, T_ext=25 → T_hr = -10 + 0.784*35 = 17.44 → coil to 18
+        # Both reach 18 °C setpoint, but HR powers differ — test that zone_temperature_c
+        # (extract temperature) is used, not a fixed value.
+        bdy_cool = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-10.0,
+            wind_speed_m_s=0.0,
+        )
+        bdy_warm = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=25.0,
+            outdoor_temperature_c=-10.0,
+            wind_speed_m_s=0.0,
+        )
+        # Both supply at 18 °C, same flow → same H_ve and S_ve
+        assert bdy_cool.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+        assert bdy_warm.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+        # H_ve identical (same flow rate)
+        assert bdy_cool.heat_transfer_coefficient_w_k == pytest.approx(
+            bdy_warm.heat_transfer_coefficient_w_k, rel=1e-9
+        )
+
+    def test_frost_protection_reduces_hr_at_extreme_cold(self):
+        """At T_oda=-15, EXHAUST_LIMIT frost protection reduces effective HR."""
+        # Without frost: T_eha = 21 - 0.784*36 = -7.2 < -5 → frost kicks in
+        # eta_frost = (21-(-5))/36 = 26/36; T_hr = -15 + (26/36)*36 = 11 °C
+        # Supply = 18 °C (coil covers the gap)
+        bdy = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-15.0,
+            wind_speed_m_s=0.0,
+        )
+        # Supply still reaches setpoint; but note stream H_ve unchanged (full flow)
+        assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+
+    def test_unknown_type_still_raises(self):
+        """Unknown ventilation_type still raises ValueError after adding mechanical_supply."""
+        bld = _ahu_building([{
+            "name": "x",
+            "ventilation_type": "magic_box",
+        }])
+        with pytest.raises(ValueError, match="unknown ventilation_type"):
+            resolve_ventilation_boundary(bld, 21.0, -5.0, 0.0)

--- a/tests/test_ventilation_boundary.py
+++ b/tests/test_ventilation_boundary.py
@@ -56,44 +56,22 @@ class TestVentilationStream:
         )
         assert s.heat_transfer_coefficient_w_k == 0.0
 
-    def test_negative_conductance_rejected(self):
-        with pytest.raises(ValueError, match="H_k must be >= 0"):
+    @pytest.mark.parametrize(
+        ("name", "h_k", "t_src", "match"),
+        [
+            ("x", -1.0, 10.0, "H_k must be >= 0"),
+            ("x", float("nan"), 10.0, "H_k must be finite"),
+            ("x", float("inf"), 10.0, "H_k must be finite"),
+            ("x", 100.0, float("nan"), "source_temperature_c must be finite"),
+            ("", 100.0, 5.0, "name must be non-empty"),
+        ],
+    )
+    def test_stream_rejects_invalid(self, name, h_k, t_src, match):
+        with pytest.raises(ValueError, match=match):
             VentilationStream(
-                name="bad",
-                heat_transfer_coefficient_w_k=-1.0,
-                source_temperature_c=10.0,
-            )
-
-    def test_nan_conductance_rejected(self):
-        with pytest.raises(ValueError, match="H_k must be finite"):
-            VentilationStream(
-                name="nan",
-                heat_transfer_coefficient_w_k=float("nan"),
-                source_temperature_c=10.0,
-            )
-
-    def test_inf_conductance_rejected(self):
-        with pytest.raises(ValueError, match="H_k must be finite"):
-            VentilationStream(
-                name="inf",
-                heat_transfer_coefficient_w_k=float("inf"),
-                source_temperature_c=10.0,
-            )
-
-    def test_nan_source_temperature_rejected(self):
-        with pytest.raises(ValueError, match="source_temperature_c must be finite"):
-            VentilationStream(
-                name="nan_temp",
-                heat_transfer_coefficient_w_k=100.0,
-                source_temperature_c=float("nan"),
-            )
-
-    def test_empty_name_rejected(self):
-        with pytest.raises(ValueError, match="name must be non-empty"):
-            VentilationStream(
-                name="",
-                heat_transfer_coefficient_w_k=100.0,
-                source_temperature_c=5.0,
+                name=name,
+                heat_transfer_coefficient_w_k=h_k,
+                source_temperature_c=t_src,
             )
 
     def test_frozen_immutable(self):
@@ -1348,7 +1326,8 @@ def _run_legacy(building, n=48, t_out=-5.0, profile_df=None):
 
 
 class TestLegacyCausalSolverPaths:
-    """Verify affine boundary in legacy and causal solver paths (utils.py lines ~6515, ~8047)."""
+    """Verify the affine boundary end-to-end in the legacy and causal single-zone
+    solver cores (via utils.py::_resolve_single_zone_vent_boundary)."""
 
     def test_legacy_prescribed_h_ve_appears_in_output(self):
         """Legacy solver must emit H_ve matching the prescribed component H_k."""
@@ -1657,7 +1636,8 @@ def _run_causal(building, n=48, t_out=-5.0, profile_df=None):
 
 
 class TestCausalSolverPath:
-    """Verify affine boundary in the causal solver path (utils.py ~8047 and ~8072)."""
+    """Verify the affine boundary end-to-end in the causal solver core
+    (via utils.py::_resolve_single_zone_vent_boundary)."""
 
     def test_causal_prescribed_h_ve_in_output(self):
         """Causal solver must emit H_ve matching the prescribed component H_k."""
@@ -1706,9 +1686,9 @@ class TestCausalSolverPath:
     def test_causal_mixed_profile_end_to_end(self):
         """Causal solver end-to-end: AHU schedule toggles H_ve between two states.
 
-        Mirrors test_legacy_mixed_profile_end_to_end for the causal path
-        (_comp_mult_leg extraction at utils.py ~8088).  Would fail if the
-        schedule-extraction code were removed from the causal core.
+        Mirrors test_legacy_mixed_profile_end_to_end for the causal path.
+        Would fail if the _comp_mult_leg schedule extraction were removed
+        from the causal core.
         """
         rho, cp, ach, vol = 1.204, 1006.0, 0.015, 300.0
         h_inf = rho * cp * ach * vol / 3600.0
@@ -1810,8 +1790,8 @@ class TestMechanicalSupplyComponent:
         # equivalent_supply_temperature_c = S_ve / H_ve
         assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
 
-    def test_ahu_off_when_operation_fraction_zero(self):
-        """An AHU with operation_fraction=0 contributes zero H_ve and S_ve."""
+    def test_ahu_off_when_flow_fraction_zero(self):
+        """An AHU with flow_fraction=0.0 contributes zero H_ve and S_ve."""
         bdy = resolve_ventilation_boundary(
             _ahu_building([_ahu_component()]),
             zone_temperature_c=21.0,
@@ -2032,8 +2012,8 @@ class TestMechanicalSupplyComponent:
 # _ahu_coll_to_columns integration: column contract, types, and edge cases
 # ---------------------------------------------------------------------------
 
-from pybuildingenergy.source.ventilation_16798_5_1 import AHUStepOutputs
-from pybuildingenergy.source.utils import _ahu_coll_to_columns
+from pybuildingenergy.source.ventilation_16798_5_1 import AHUStepOutputs, calculate_sensible_ahu_step
+from pybuildingenergy.source.utils import _ahu_coll_to_columns, _AHU_DIAG_SPEC
 
 
 def _make_step_outputs(**overrides) -> AHUStepOutputs:
@@ -2130,3 +2110,179 @@ class TestAhuCollToColumns:
     def test_empty_collector_returns_empty_dict(self):
         assert _ahu_coll_to_columns([]) == {}
         assert _ahu_coll_to_columns([{}, {}]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers for multizone-solver AHU tests
+# ---------------------------------------------------------------------------
+
+def _outdoor_wall_surface(zone_name, area=50.0):
+    """Minimal outdoor opaque wall that creates creates thermal mass so T_air and T_op diverge."""
+    return {
+        "name": f"south_wall_{zone_name}",
+        "type": "opaque",
+        "boundary": "OUTDOORS",
+        "area": area,
+        "zone": zone_name,
+        "sky_view_factor": 0.5,
+        "u_value": 0.3,
+        "thermal_capacity": 80000.0,
+        "solar_absorptance": 0.6,
+        "orientation": {"azimuth": 180, "tilt": 90},
+    }
+
+
+def _ahu_zone_building(components):
+    """One-zone building with component-list ventilation for the multizone solver."""
+    return {
+        "building": {
+            "net_floor_area": 100.0,
+            "building_type_class": "Residential_apartment",
+            "adj_zones_present": False,
+            "construction_class": "class_i",
+        },
+        "building_parameters": {"ventilation": {}, "temperature_setpoints": {}},
+        "building_surface": [_adiabatic_surface("zone1")],
+        "zones": [{
+            "name": "zone1",
+            "net_floor_area": 100.0,
+            "heating_setpoint": 21.0,
+            "heating_setback": 15.0,
+            "cooling_setpoint": 26.0,
+            "cooling_setback": 30.0,
+            "ventilation": {"components": components},
+        }],
+    }
+
+
+def _ahu_zone_building_with_mass(components):
+    """One-zone building with an outdoor wall, so T_air != T_op under HVAC control.
+
+    The wall surface nodes (Pln=5) are initialized to 20 °C and lag behind the air
+    node after heating begins, giving T_rad < T_air and therefore T_op < T_air.
+    """
+    return {
+        "building": {
+            "net_floor_area": 100.0,
+            "building_type_class": "Residential_apartment",
+            "adj_zones_present": False,
+            "construction_class": "class_i",
+        },
+        "building_parameters": {"ventilation": {}, "temperature_setpoints": {}},
+        "building_surface": [
+            _adiabatic_surface("zone1"),
+            _outdoor_wall_surface("zone1"),
+        ],
+        "zones": [{
+            "name": "zone1",
+            "net_floor_area": 100.0,
+            "heating_setpoint": 21.0,
+            "heating_setback": 15.0,
+            "cooling_setpoint": 26.0,
+            "cooling_setback": 30.0,
+            "ventilation": {"components": components},
+        }],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mechanical-supply flow-fraction pre-validation
+# ---------------------------------------------------------------------------
+
+class TestMechanicalSupplyFlowFractionValidation:
+    """component_fraction is validated before AHUStepInputs so the error names the component."""
+
+    @pytest.mark.parametrize("bad_fraction", [-0.1, 1.1, float("nan")])
+    def test_invalid_flow_fraction_raises_with_component_name(self, bad_fraction):
+        with pytest.raises(ValueError, match="ahu"):
+            resolve_ventilation_boundary(
+                _ahu_building([_ahu_component()]),
+                zone_temperature_c=21.0,
+                outdoor_temperature_c=-5.0,
+                wind_speed_m_s=0.0,
+                component_multipliers={"ahu": bad_fraction},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Multizone solver — AHU diagnostic output contract
+# ---------------------------------------------------------------------------
+
+class TestMultizoneAhuDiagnostics:
+    """Multizone solver output must contain all 12 _AHU_DIAG_SPEC fields per component."""
+
+    def test_all_12_diagnostic_columns_present(self):
+        bld = _ahu_zone_building([_ahu_component()])
+        with _patched_weather(n=4):
+            out = ISO52016.simulate_envelope_multizone_free_floating(
+                building_object=bld,
+            )
+        # Verify each _AHU_DIAG_SPEC prefix appears as a column
+        for col_pfx, attr, dtype in _AHU_DIAG_SPEC:
+            col = f"{col_pfx}_ahu_zone1"
+            assert col in out.columns, (
+                f"Expected multizone diagnostic column {col!r} missing from output. "
+                f"Present AHU columns: {[c for c in out.columns if 'ahu' in c.lower()]}"
+            )
+
+    def test_diagnostic_values_are_finite_for_operating_ahu(self):
+        bld = _ahu_zone_building([_ahu_component()])
+        with _patched_weather(n=4, t_out=-5.0):
+            out = ISO52016.simulate_envelope_multizone_free_floating(
+                building_object=bld,
+            )
+        # Numeric fields (excluding frost int and optional requested_supply_temperature_c)
+        float_cols = [
+            f"{col_pfx}_ahu_zone1"
+            for col_pfx, _, dtype in _AHU_DIAG_SPEC
+            if dtype == float and col_pfx != "T_ahu_sup_req"
+        ]
+        for col in float_cols:
+            assert np.all(np.isfinite(out[col].to_numpy())), (
+                f"Column {col!r} has non-finite values: {out[col].to_numpy()}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Multizone solver — extract-temperature coupling regression
+# ---------------------------------------------------------------------------
+
+class TestMultizoneAhuCouplingLag:
+    """AHU receives the previous-timestep zone AIR temperature as extract temperature."""
+
+    def test_extract_temperature_equals_previous_air_not_operative(self):
+        """Verify T_extract = T_air[t-1], not T_op[t-1], with T_air != T_op.
+
+        _ahu_zone_building_with_mass provides an outdoor wall whose surface nodes
+        (Pln=5, initialized to 20 °C) lag behind the air node after HVAC heats the
+        zone.  This gives T_rad < T_air and therefore T_op != T_air by > 0.5 K,
+        making the air-vs-operative distinction detectable.
+        """
+        bld = _ahu_zone_building_with_mass([_ahu_component()])
+        captured = []
+
+        def _capture(cfg, inp):
+            captured.append(inp)
+            return calculate_sensible_ahu_step(cfg, inp)
+
+        with patch(
+            "pybuildingenergy.source.ventilation_16798_5_1.calculate_sensible_ahu_step",
+            side_effect=_capture,
+        ):
+            with _patched_weather(n=4):
+                out = ISO52016.simulate_envelope_multizone_free_floating(
+                    building_object=bld,
+                )
+
+        assert len(captured) >= 2, "Expected at least 2 AHU calls (one per timestep)"
+        t_air_step0 = float(out["T_air_zone1"].iloc[0])
+        t_op_step0 = float(out["T_op_zone1"].iloc[0])
+
+        # Fixture must produce a meaningful T_air / T_op difference
+        assert abs(t_air_step0 - t_op_step0) > 0.5, (
+            f"Fixture did not produce T_air != T_op: T_air={t_air_step0:.3f}, "
+            f"T_op={t_op_step0:.3f}"
+        )
+        # Extract temperature must equal previous AIR temperature, not operative
+        assert captured[1].extract_temperature_c == pytest.approx(t_air_step0, abs=1e-6)
+        assert abs(captured[1].extract_temperature_c - t_op_step0) > 0.5

--- a/tests/test_ventilation_boundary.py
+++ b/tests/test_ventilation_boundary.py
@@ -1971,6 +1971,41 @@ class TestMechanicalSupplyComponent:
         assert coll["ahu"].actual_heating_coil_power_w >= 0.0
         assert coll["ahu"].heat_recovery_power_w >= 0.0
 
+    def test_component_multiplier_is_flow_fraction_for_en16798_fan(self):
+        """Component schedules reduce flow, not timestep availability."""
+        component = _ahu_component(
+            supply_fan_specific_power_w_per_m3_s=500.0,
+            extract_fan_specific_power_w_per_m3_s=0.0,
+            fan_performance_model="en16798_5_1",
+        )
+        coll_full = {}
+        bdy_full = resolve_ventilation_boundary(
+            _ahu_building([component]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            component_multipliers={"ahu": 1.0},
+            ahu_outputs_collector=coll_full,
+        )
+        coll_part = {}
+        bdy_part = resolve_ventilation_boundary(
+            _ahu_building([component]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            component_multipliers={"ahu": 0.25},
+            ahu_outputs_collector=coll_part,
+        )
+
+        assert bdy_part.heat_transfer_coefficient_w_k == pytest.approx(
+            0.25 * bdy_full.heat_transfer_coefficient_w_k,
+            rel=1e-9,
+        )
+        assert coll_part["ahu"].fan_electric_power_w == pytest.approx(
+            coll_full["ahu"].fan_electric_power_w * 0.25 ** 2.5,
+            rel=1e-9,
+        )
+
     def test_ahu_outputs_collector_empty_when_no_mechanical_supply(self):
         """No mechanical_supply components → collector is untouched."""
         coll = {}
@@ -1991,3 +2026,105 @@ class TestMechanicalSupplyComponent:
         }])
         with pytest.raises(ValueError, match="unknown ventilation_type"):
             resolve_ventilation_boundary(bld, 21.0, -5.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _ahu_coll_to_columns integration: column contract, types, and edge cases
+# ---------------------------------------------------------------------------
+
+from pybuildingenergy.source.ventilation_16798_5_1 import AHUStepOutputs
+from pybuildingenergy.source.utils import _ahu_coll_to_columns
+
+
+def _make_step_outputs(**overrides) -> AHUStepOutputs:
+    defaults = dict(
+        requested_supply_temperature_c=18.5,
+        actual_supply_temperature_c=18.5,
+        actual_supply_flow_m3_h=1000.0,
+        actual_extract_flow_m3_h=1000.0,
+        required_heating_coil_power_w=500.0,
+        actual_heating_coil_power_w=500.0,
+        required_cooling_coil_power_w=0.0,
+        fan_electric_power_w=200.0,
+        heat_recovery_power_w=3000.0,
+        bypass_fraction=0.0,
+        frost_protection_required=False,
+    )
+    defaults.update(overrides)
+    return AHUStepOutputs(**defaults)
+
+
+class TestAhuCollToColumns:
+    """_ahu_coll_to_columns — column contract, types, warm-up slicing, off-hours."""
+
+    def test_expected_column_names_single_component(self):
+        out = _make_step_outputs()
+        cols = _ahu_coll_to_columns([{"ahu": out}])
+        expected = {
+            "Q_ahu_coil_ahu", "Q_ahu_coil_req_ahu", "Q_ahu_cool_req_ahu",
+            "Q_ahu_hr_ahu", "P_ahu_fan_ahu",
+            "T_ahu_sup_ahu", "T_ahu_sup_req_ahu",
+            "q_sup_m3h_ahu", "q_ext_m3h_ahu",
+            "ahu_bypass_ahu", "ahu_frost_ahu",
+        }
+        assert set(cols.keys()) == expected
+
+    def test_frost_is_integer_not_float(self):
+        out = _make_step_outputs(frost_protection_required=True)
+        cols = _ahu_coll_to_columns([{"ahu": out}])
+        assert cols["ahu_frost_ahu"].dtype == np.dtype("int64")
+        assert cols["ahu_frost_ahu"][0] == 1
+
+    def test_frost_false_gives_zero(self):
+        out = _make_step_outputs(frost_protection_required=False)
+        cols = _ahu_coll_to_columns([{"ahu": out}])
+        assert cols["ahu_frost_ahu"][0] == 0
+
+    def test_requested_temp_none_when_ahu_off_is_nan(self):
+        out_off = _make_step_outputs(requested_supply_temperature_c=None)
+        cols = _ahu_coll_to_columns([{"ahu": out_off}])
+        assert np.isnan(cols["T_ahu_sup_req_ahu"][0])
+
+    def test_values_match_step_outputs_fields(self):
+        out = _make_step_outputs()
+        cols = _ahu_coll_to_columns([{"ahu": out}])
+        assert cols["Q_ahu_coil_ahu"][0]    == pytest.approx(500.0)
+        assert cols["Q_ahu_hr_ahu"][0]      == pytest.approx(3000.0)
+        assert cols["P_ahu_fan_ahu"][0]     == pytest.approx(200.0)
+        assert cols["T_ahu_sup_ahu"][0]     == pytest.approx(18.5)
+        assert cols["T_ahu_sup_req_ahu"][0] == pytest.approx(18.5)
+        assert cols["q_sup_m3h_ahu"][0]     == pytest.approx(1000.0)
+        assert cols["q_ext_m3h_ahu"][0]     == pytest.approx(1000.0)
+        assert cols["ahu_bypass_ahu"][0]    == pytest.approx(0.0)
+
+    def test_multiple_components_produce_separate_suffixes(self):
+        out1 = _make_step_outputs(actual_supply_temperature_c=19.0)
+        out2 = _make_step_outputs(actual_supply_temperature_c=17.0)
+        cols = _ahu_coll_to_columns([{"ahu1": out1, "ahu2": out2}])
+        assert "T_ahu_sup_ahu1" in cols
+        assert "T_ahu_sup_ahu2" in cols
+        assert cols["T_ahu_sup_ahu1"][0] == pytest.approx(19.0)
+        assert cols["T_ahu_sup_ahu2"][0] == pytest.approx(17.0)
+
+    def test_warmup_slice_alignment_matches_timestep_count(self):
+        """When a warm-up period is sliced away, column arrays must match the slice length."""
+        n_warmup = 744   # December warm-up (31 days)
+        n_year   = 8760
+        on = _make_step_outputs()
+        full_coll = [{"ahu": on}] * (n_warmup + n_year)
+        act_slice = slice(n_warmup, None)
+        cols = _ahu_coll_to_columns(full_coll[act_slice])
+        assert len(cols["Q_ahu_coil_ahu"]) == n_year
+
+    def test_missing_component_in_some_timesteps_gives_nan(self):
+        """Component absent from a timestep dict should yield NaN for that hour."""
+        on  = _make_step_outputs(actual_heating_coil_power_w=999.0)
+        off = {}   # AHU off — component not in dict
+        cols = _ahu_coll_to_columns([{"ahu": on}, off, {"ahu": on}])
+        assert cols["Q_ahu_coil_ahu"][0] == pytest.approx(999.0)
+        assert np.isnan(cols["Q_ahu_coil_ahu"][1])
+        assert cols["Q_ahu_coil_ahu"][2] == pytest.approx(999.0)
+
+    def test_empty_collector_returns_empty_dict(self):
+        assert _ahu_coll_to_columns([]) == {}
+        assert _ahu_coll_to_columns([{}, {}]) == {}

--- a/tests/test_ventilation_boundary.py
+++ b/tests/test_ventilation_boundary.py
@@ -1893,44 +1893,95 @@ class TestMechanicalSupplyComponent:
         assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
 
     def test_extract_temperature_affects_hr(self):
-        """Higher extract temperature → more HR power → higher supply temperature."""
-        # At T_oda=-10, T_ext=21 → T_hr = -10 + 0.784*31 = 14.304 → coil to 18
-        # At T_oda=-10, T_ext=25 → T_hr = -10 + 0.784*35 = 17.44 → coil to 18
-        # Both reach 18 °C setpoint, but HR powers differ — test that zone_temperature_c
-        # (extract temperature) is used, not a fixed value.
-        bdy_cool = resolve_ventilation_boundary(
-            _ahu_building([_ahu_component()]),
+        """zone_temperature_c is passed as extract temperature — different T_ext → different supply.
+
+        With no heating coil the supply equals the HR outlet, which depends on extract
+        temperature.  An unlimited coil would hide the difference by topping up to 18 °C
+        in both cases; this test uses heating_coil_max_power_w=0 to expose the physics.
+
+        T_oda=-10, T_ext=21: T_hr = -10 + 0.784*31 = 14.304 °C  (no frost: T_eha = -3.3 > -5)
+        T_oda=-10, T_ext=25: T_hr = -10 + 0.784*35 = 17.44  °C  (no frost: T_eha = -2.4 > -5)
+        """
+        no_coil = dict(heating_coil_max_power_w=0.0)
+        bdy_21 = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component(**no_coil)]),
             zone_temperature_c=21.0,
             outdoor_temperature_c=-10.0,
             wind_speed_m_s=0.0,
         )
-        bdy_warm = resolve_ventilation_boundary(
-            _ahu_building([_ahu_component()]),
+        bdy_25 = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component(**no_coil)]),
             zone_temperature_c=25.0,
             outdoor_temperature_c=-10.0,
             wind_speed_m_s=0.0,
         )
-        # Both supply at 18 °C, same flow → same H_ve and S_ve
-        assert bdy_cool.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
-        assert bdy_warm.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
-        # H_ve identical (same flow rate)
-        assert bdy_cool.heat_transfer_coefficient_w_k == pytest.approx(
-            bdy_warm.heat_transfer_coefficient_w_k, rel=1e-9
-        )
+        # Without a coil, supply = T_hr exactly
+        assert bdy_21.equivalent_supply_temperature_c == pytest.approx(-10 + 0.784 * 31, rel=1e-5)
+        assert bdy_25.equivalent_supply_temperature_c == pytest.approx(-10 + 0.784 * 35, rel=1e-5)
+        # Higher extract → more HR → warmer supply
+        assert bdy_25.equivalent_supply_temperature_c > bdy_21.equivalent_supply_temperature_c
 
     def test_frost_protection_reduces_hr_at_extreme_cold(self):
-        """At T_oda=-15, EXHAUST_LIMIT frost protection reduces effective HR."""
-        # Without frost: T_eha = 21 - 0.784*36 = -7.2 < -5 → frost kicks in
-        # eta_frost = (21-(-5))/36 = 26/36; T_hr = -15 + (26/36)*36 = 11 °C
-        # Supply = 18 °C (coil covers the gap)
-        bdy = resolve_ventilation_boundary(
-            _ahu_building([_ahu_component()]),
+        """EXHAUST_LIMIT frost protection actively reduces effective HR efficiency.
+
+        With no heating coil the frost-limited HR outlet is directly observable as
+        the delivered supply temperature.  Comparing against frost_control='none'
+        confirms the efficiency reduction is real, not masked by the coil.
+
+        T_oda=-15, T_ext=21, eta=0.784, frost_limit=-5 (default):
+          T_eha_nom = 21 - 0.784*36 = -7.224 °C  < -5  → frost active
+          eta_frost  = (21 - (-5)) / 36 = 26/36
+          T_hr_frost = -15 + (26/36)*36 = 11.0 °C
+        Without frost (mode='none'):
+          T_hr       = -15 + 0.784*36  = 13.224 °C
+        """
+        no_coil = dict(heating_coil_max_power_w=0.0)
+        bdy_frost = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component(**no_coil)]),
             zone_temperature_c=21.0,
             outdoor_temperature_c=-15.0,
             wind_speed_m_s=0.0,
         )
-        # Supply still reaches setpoint; but note stream H_ve unchanged (full flow)
-        assert bdy.equivalent_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+        bdy_no_frost = resolve_ventilation_boundary(
+            _ahu_building([_ahu_component(**no_coil, frost_control="none")]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-15.0,
+            wind_speed_m_s=0.0,
+        )
+        assert bdy_frost.equivalent_supply_temperature_c == pytest.approx(11.0, abs=1e-6)
+        assert bdy_no_frost.equivalent_supply_temperature_c == pytest.approx(
+            -15 + 0.784 * 36, rel=1e-5
+        )
+        assert bdy_frost.equivalent_supply_temperature_c < bdy_no_frost.equivalent_supply_temperature_c
+
+    def test_ahu_outputs_collector_captures_step_results(self):
+        """ahu_outputs_collector receives AHUStepOutputs for every mechanical_supply component."""
+        coll = {}
+        resolve_ventilation_boundary(
+            _ahu_building([_ahu_component()]),
+            zone_temperature_c=21.0,
+            outdoor_temperature_c=-5.0,
+            wind_speed_m_s=0.0,
+            ahu_outputs_collector=coll,
+        )
+        assert "ahu" in coll
+        from pybuildingenergy.source.ventilation_16798_5_1 import AHUStepOutputs
+        assert isinstance(coll["ahu"], AHUStepOutputs)
+        assert coll["ahu"].actual_supply_temperature_c == pytest.approx(18.0, abs=1e-9)
+        assert coll["ahu"].actual_heating_coil_power_w >= 0.0
+        assert coll["ahu"].heat_recovery_power_w >= 0.0
+
+    def test_ahu_outputs_collector_empty_when_no_mechanical_supply(self):
+        """No mechanical_supply components → collector is untouched."""
+        coll = {}
+        bld = {
+            "building_parameters": {"ventilation": {"components": [
+                {"name": "inf", "ventilation_type": "constant_ach", "air_changes_per_hour": 0.5},
+            ]}}
+        }
+        resolve_ventilation_boundary(bld, 21.0, -5.0, 0.0, zone_volume_m3=1000.0,
+                                     ahu_outputs_collector=coll)
+        assert coll == {}
 
     def test_unknown_type_still_raises(self):
         """Unknown ventilation_type still raises ValueError after adding mechanical_supply."""


### PR DESCRIPTION
Adds a sensible air-handling-unit model based on EN 16798-5-1 as a `mechanical_supply` component of the ISO 52016-1 ventilation boundary.

At each timestep, the model calculates:
- heat recovery with modulating bypass and frost protection
- capacity-limited heating and cooling coils
- fixed, scheduled, outdoor-compensated, or extract-compensated supply control
- supply and extract fan electricity at part load

The conditioned airflow enters the zone balance as one supply-air stream.
Coil, heat-recovery, and fan results are exposed separately as diagnostics.

This is the follow-up to the ventilation-boundary work and the design discussed
in #16 .

## Implementation

- Adds a standalone AHU module using frozen dataclasses  (`SensibleAHUConfig`, `AHUStepInputs`, `AHUStepOutputs`).
- Integrates `mechanical_supply` into `resolve_ventilation_boundary()`.
- Adds the same 12 hourly AHU diagnostics to the legacy, causal, and multizone
  solver paths.
- Documents configuration, assumptions, calculation order, and diagnostics in
  the ventilation chapter and the new AHU audit page.

Supply air-path order:

`heat recovery → cooling coil → heating coil → supply fan`

## Review Notes

- **Extract coupling:** uses the previous timestep's zone air-node temperature,
  avoiding an algebraic loop.
- **Scope:** sensible-only, balanced flow; humidity, recirculation, duct losses,
  and unbalanced-flow interactions are not modeled.
- **Profiles:** component profiles are continuous flow fractions in `[0, 1]`,
  not duty-cycle averages.
- **Air properties:** uses the existing fixed `ρ·cp = 1211.224 J/(m³·K)`.
- **Fan defaults:** the EN 16798-5-1 model uses part-load pressure and efficiency
  relations. A simpler `constant_sfp` model is also available.
- **Energy reporting:** coil energy is reported as a diagnostic

## Documentation

- `docs/ventilation_ahu_audit.html`
- `docs/simulation_workflow_audit.html`
- `src/pybuildingenergy/source/ventilation_chapter.md`
- `Readme.md`

## Tests

```console
uv run pytest -q tests/test_ventilation_16798_5_1.py tests/test_ventilation_boundary.py
